### PR TITLE
Renaming client usage throughout the modules

### DIFF
--- a/redisplus/ai/__init__.py
+++ b/redisplus/ai/__init__.py
@@ -2,11 +2,12 @@ from functools import wraps, partial
 
 from redis.commands import Commands as RedisCommands
 import redis
+from ..feature import AbstractFeature
 
 from .commands import *
 
 
-class AI(CommandMixin, RedisCommands, object):
+class AI(CommandMixin, AbstractFeature, object):
     """
     Redis client build specifically for the RedisAI module. It takes all the necessary
     parameters to establish the connection and an optional ``debug`` parameter on
@@ -29,18 +30,10 @@ class AI(CommandMixin, RedisCommands, object):
     REDISAI_COMMANDS_RESPONSE_CALLBACKS = {}
 
     def __init__(self, client=None, debug=False, enable_postprocess=True):
-        self.CLIENT = client
+        self.client = client
         # if debug:
         #     self.execute_command = enable_debug(super().execute_command)
         self.enable_postprocess = enable_postprocess
-
-    def execute_command(self, *args, **kwargs):
-        return self.client.execute_command(*args, **kwargs)
-
-    @property
-    def client(self):
-        return self.CLIENT
-
 
 # def enable_debug(f):
 #     @wraps(f)

--- a/redisplus/ai/__init__.py
+++ b/redisplus/ai/__init__.py
@@ -35,6 +35,7 @@ class AI(CommandMixin, AbstractFeature, object):
         #     self.execute_command = enable_debug(super().execute_command)
         self.enable_postprocess = enable_postprocess
 
+
 # def enable_debug(f):
 #     @wraps(f)
 #     def wrapper(*args):

--- a/redisplus/bf/__init__.py
+++ b/redisplus/bf/__init__.py
@@ -76,6 +76,7 @@ class Bloom(CommandMixin, AbstractFeature, object):
         }
 
         self.client = client
+        self.commandmixin = CommandMixin
 
         for k, v in MODULE_CALLBACKS.items():
             self.client.set_response_callback(k, v)
@@ -148,9 +149,3 @@ class Bloom(CommandMixin, AbstractFeature, object):
         """Append BUCKETSIZE to params."""
         if bucket_size is not None:
             params.extend(["BUCKETSIZE", bucket_size])
-
-    def pipeline(self, **kwargs):
-        p = self._pipeline(
-            CommandMixin,
-        )
-        return p

--- a/redisplus/bf/__init__.py
+++ b/redisplus/bf/__init__.py
@@ -75,19 +75,10 @@ class Bloom(CommandMixin, AbstractFeature, object):
             TDIGEST_INFO: TDigestInfo,
         }
 
-        self.CLIENT = client
+        self.client = client
 
         for k, v in MODULE_CALLBACKS.items():
             self.client.set_response_callback(k, v)
-
-    @property
-    def client(self):
-        """Get the client."""
-        return self.CLIENT
-
-    def execute_command(self, *args, **kwargs):
-        """Execute redis command."""
-        return self.client.execute_command(*args, **kwargs)
 
     @staticmethod
     def appendItems(params, items):

--- a/redisplus/client.py
+++ b/redisplus/client.py
@@ -24,34 +24,35 @@ class Client(Commands, object):
         """
         if client is None:
             client = Redis()
-        self.__client__ = client
+        self.client = client
 
         self.__extras__ = extras
 
     @property
-    def client(self):
-        """Return the redis client, used for this connection."""
-        return self.__client__
+    def __client__(self):
+        """Return the internal representation of the redis client
+        used for this connection. This is not public."""
+        return self.client
 
     @property
     def json(self):
-        """For running json specific commands."""
+        """For running json commands."""
         kwargs = self.__extras__.get("json", {})
         import redisplus.json
 
         return redisplus.json.JSON(self.client, **kwargs)
 
     @property
-    def bloom(self):
-        """For running bloom specific commands."""
+    def bf(self):
+        """For running bloom commands."""
         kwargs = self.__extras__.get("bf", {})
         import redisplus.bf
 
         return redisplus.bf.Bloom(self.client, **kwargs)
 
     @property
-    def timeseries(self):
-        """For running bloom specific commands."""
+    def tf(self):
+        """For running timeseries commands."""
         kwargs = self.__extras__.get("ts", {})
         import redisplus.ts
 
@@ -67,8 +68,8 @@ class Client(Commands, object):
 
     def execute_command(self, *args, **kwargs):
         """Pull in and excecute the redis commands"""
-        return self.client.execute_command(*args, **kwargs)
+        return self.__client__.execute_command(*args, **kwargs)
 
     def pipeline(self, *args, **kwargs):
         """Pipelines"""
-        return self.client.pipeline(*args, **kwargs)
+        return self.__client__.pipeline(*args, **kwargs)

--- a/redisplus/feature.py
+++ b/redisplus/feature.py
@@ -14,9 +14,9 @@ class AbstractFeature(ABC):
         return self.client.execute_command(*args, **kwargs)
 
     @property
-    def client(self):
-        """Get the client instance."""
-        return self.CLIENT
+    def __client__(self):
+        """Get the client instance set by the redis module class."""
+        return self.client
 
     def _pipeline(self, cls, **kwargs):
         """Build and return a pipeline object.

--- a/redisplus/json/__init__.py
+++ b/redisplus/json/__init__.py
@@ -61,6 +61,7 @@ class JSON(CommandMixin, AbstractFeature, object):
         }
 
         self.client = client
+        self.commandmixin = CommandMixin
 
         for key, value in self.MODULE_CALLBACKS.items():
             self.client.set_response_callback(key, value)
@@ -86,7 +87,6 @@ class JSON(CommandMixin, AbstractFeature, object):
 
     def pipeline(self, **kwargs):
         p = self._pipeline(
-            CommandMixin,
             __encode__=self.__encoder__,
             _encode=self._encode,
             __decoder__=self.__decoder__,

--- a/redisplus/json/__init__.py
+++ b/redisplus/json/__init__.py
@@ -60,7 +60,7 @@ class JSON(CommandMixin, AbstractFeature, object):
             "JSON.DEBUG": int,
         }
 
-        self.CLIENT = client
+        self.client = client
 
         for key, value in self.MODULE_CALLBACKS.items():
             self.client.set_response_callback(key, value)

--- a/redisplus/ts/__init__.py
+++ b/redisplus/ts/__init__.py
@@ -40,7 +40,7 @@ class TimeSeries(CommandMixin, AbstractFeature, object):
             QUERYINDEX_CMD: parseToList,
         }
 
-        self.CLIENT = client
+        self.client = client
 
         for k in MODULE_CALLBACKS:
             self.client.set_response_callback(k, MODULE_CALLBACKS[k])

--- a/redisplus/ts/__init__.py
+++ b/redisplus/ts/__init__.py
@@ -41,12 +41,7 @@ class TimeSeries(CommandMixin, AbstractFeature, object):
         }
 
         self.client = client
+        self.commandmixin = CommandMixin
 
         for k in MODULE_CALLBACKS:
             self.client.set_response_callback(k, MODULE_CALLBACKS[k])
-
-    def pipeline(self, **kwargs):
-        p = self._pipeline(
-            CommandMixin,
-        )
-        return p

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -409,7 +409,9 @@ def test_deprecated_scriptset_and_scriptrun(client):
     assert [4, 6] == tensor["values"]
 
     # test bar_variadic(a, args : List[Tensor])
-    client.ai.scriptrun("scr", "bar_variadic", inputs=["a", "$", "b", "b"], outputs=["c"])
+    client.ai.scriptrun(
+        "scr", "bar_variadic", inputs=["a", "$", "b", "b"], outputs=["c"]
+    )
     tensor = client.ai.tensorget("c", as_numpy=False)
     assert [4, 6] == tensor["values"]
 

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -89,47 +89,47 @@ def get_client(debug=False):
 def client():
     rc = Client()
     rc.flushdb()
-    return rc.ai
+    return rc
 
 
 @pytest.mark.integrations
 @pytest.mark.ai
 def test_set_non_numpy_tensor(client):
-    client.tensorset("x", (2, 3, 4, 5), dtype="float")
-    result = client.tensorget("x", as_numpy=False)
+    client.ai.tensorset("x", (2, 3, 4, 5), dtype="float")
+    result = client.ai.tensorget("x", as_numpy=False)
     assert [2, 3, 4, 5] == result["values"]
     assert [4] == result["shape"]
 
-    client.tensorset("x", (2, 3, 4, 5), dtype="float64")
-    result = client.tensorget("x", as_numpy=False)
+    client.ai.tensorset("x", (2, 3, 4, 5), dtype="float64")
+    result = client.ai.tensorget("x", as_numpy=False)
     assert [2, 3, 4, 5] == result["values"]
     assert [4] == result["shape"]
     assert "DOUBLE" == result["dtype"]
 
-    client.tensorset("x", (2, 3, 4, 5), dtype="int16", shape=(2, 2))
-    result = client.tensorget("x", as_numpy=False)
+    client.ai.tensorset("x", (2, 3, 4, 5), dtype="int16", shape=(2, 2))
+    result = client.ai.tensorget("x", as_numpy=False)
     assert [2, 3, 4, 5] == result["values"]
     assert [2, 2] == result["shape"]
 
     with pytest.raises(TypeError):
-        client.tensorset("x", (2, 3, 4, 5), dtype="wrongtype", shape=(2, 2))
-    client.tensorset("x", (2, 3, 4, 5), dtype="int8", shape=(2, 2))
-    result = client.tensorget("x", as_numpy=False)
+        client.ai.tensorset("x", (2, 3, 4, 5), dtype="wrongtype", shape=(2, 2))
+    client.ai.tensorset("x", (2, 3, 4, 5), dtype="int8", shape=(2, 2))
+    result = client.ai.tensorget("x", as_numpy=False)
     assert "INT8" == result["dtype"]
     assert [2, 3, 4, 5] == result["values"]
     assert [2, 2] == result["shape"]
     assert "values" in result
 
     with pytest.raises(TypeError):
-        client.tensorset("x")
-        client.tensorset(1)
+        client.ai.tensorset("x")
+        client.ai.tensorset(1)
 
 
 @pytest.mark.integrations
 @pytest.mark.ai
 def test_tensorget_meta(client):
-    client.tensorset("x", (2, 3, 4, 5), dtype="float")
-    result = client.tensorget("x", meta_only=True)
+    client.ai.tensorset("x", (2, 3, 4, 5), dtype="float")
+    result = client.ai.tensorget("x", meta_only=True)
     assert "values" not in result
     assert [4] == result["shape"]
 
@@ -138,37 +138,37 @@ def test_tensorget_meta(client):
 @pytest.mark.ai
 def test_numpy_tensor(client):
     input_array = np.array([2, 3], dtype=np.float32)
-    client.tensorset("x", input_array)
-    values = client.tensorget("x")
+    client.ai.tensorset("x", input_array)
+    values = client.ai.tensorget("x")
     assert values.dtype == np.float32
 
     input_array = np.array([2, 3], dtype=np.float64)
-    client.tensorset("x", input_array)
-    values = client.tensorget("x")
+    client.ai.tensorset("x", input_array)
+    values = client.ai.tensorget("x")
     assert values.dtype == np.float64
 
     input_array = np.array([2, 3])
-    client.tensorset("x", input_array)
-    values = client.tensorget("x")
+    client.ai.tensorset("x", input_array)
+    values = client.ai.tensorget("x")
 
     assert np.allclose([2, 3], values)
     assert values.dtype == np.int64
     assert values.shape == (2,)
     assert np.allclose(values, input_array)
-    ret = client.tensorset("x", values)
+    ret = client.ai.tensorset("x", values)
     assert ret == "OK"
 
     # By default tensorget returns immutable, unless as_numpy_mutable is set as True
-    ret = client.tensorget("x")
+    ret = client.ai.tensorget("x")
     with pytest.raises(ValueError):
         np.put(ret, 0, 1)
-    ret = client.tensorget("x", as_numpy_mutable=True)
+    ret = client.ai.tensorget("x", as_numpy_mutable=True)
     np.put(ret, 0, 1)
     assert ret[0] == 1
 
     stringarr = np.array("dummy")
     with pytest.raises(TypeError):
-        client.tensorset("trying", stringarr)
+        client.ai.tensorset("trying", stringarr)
 
 
 @pytest.mark.integrations
@@ -179,7 +179,7 @@ def test_deprecated_modelset(client):
     model_pb = load_model(model_path)
 
     with pytest.raises(ValueError):
-        client.modelset(
+        client.ai.modelset(
             "m",
             "tf",
             "wrongdevice",
@@ -189,7 +189,7 @@ def test_deprecated_modelset(client):
             tag="v1.0",
         )
     with pytest.raises(ValueError):
-        client.modelset(
+        client.ai.modelset(
             "m",
             "wrongbackend",
             "cpu",
@@ -198,10 +198,10 @@ def test_deprecated_modelset(client):
             outputs=["mul"],
             tag="v1.0",
         )
-    client.modelset(
+    client.ai.modelset(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"], tag="v1.0"
     )
-    model = client.modelget("m", meta_only=True)
+    model = client.ai.modelget("m", meta_only=True)
     assert model == {
         "backend": "TF",
         "batchsize": 0,
@@ -221,12 +221,12 @@ def test_modelstore_errors(client):
     model_pb = load_model(model_path)
 
     with pytest.raises(ValueError):
-        client.modelstore(
+        client.ai.modelstore(
             None, "TF", "CPU", model_pb, inputs=["a", "b"], outputs=["mul"]
         )
 
     with pytest.raises(ValueError):
-        client.modelstore(
+        client.ai.modelstore(
             "m",
             "tf",
             "wrongdevice",
@@ -237,7 +237,7 @@ def test_modelstore_errors(client):
         )
 
     with pytest.raises(ValueError):
-        client.modelstore(
+        client.ai.modelstore(
             "m",
             "wrongbackend",
             "cpu",
@@ -248,7 +248,7 @@ def test_modelstore_errors(client):
         )
 
     with pytest.raises(ValueError):
-        client.modelstore(
+        client.ai.modelstore(
             "m",
             "tf",
             "cpu",
@@ -260,7 +260,7 @@ def test_modelstore_errors(client):
         )
 
     with pytest.raises(ValueError):
-        client.modelstore(
+        client.ai.modelstore(
             "m",
             "tf",
             "cpu",
@@ -273,10 +273,10 @@ def test_modelstore_errors(client):
         )
 
     with pytest.raises(ValueError) as e:
-        client.modelstore("m", "tf", "cpu", model_pb, tag="v1.0")
+        client.ai.modelstore("m", "tf", "cpu", model_pb, tag="v1.0")
 
     with pytest.raises(ValueError) as e:
-        client.modelstore(
+        client.ai.modelstore(
             "m",
             "torch",
             "cpu",
@@ -293,10 +293,10 @@ def test_modelget_meta(client):
     model_path = os.path.join(MODEL_DIR, tf_graph)
     model_pb = load_model(model_path)
 
-    client.modelstore(
+    client.ai.modelstore(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"], tag="v1.0"
     )
-    model = client.modelget("m", meta_only=True)
+    model = client.ai.modelget("m", meta_only=True)
     assert (
         model
         == {
@@ -318,12 +318,12 @@ def test_modelexecute_non_list_input_output(client):
     model_path = os.path.join(MODEL_DIR, "graph.pb")
     model_pb = load_model(model_path)
 
-    client.modelstore(
+    client.ai.modelstore(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"], tag="v1.7"
     )
-    client.tensorset("a", (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
-    ret = client.modelexecute("m", ["a", "b"], "out")
+    client.ai.tensorset("a", (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
+    ret = client.ai.modelexecute("m", ["a", "b"], "out")
     assert ret == "OK"
 
 
@@ -333,7 +333,7 @@ def test_nonasciichar(client):
     nonascii = "ĉ"
     model_path = os.path.join(MODEL_DIR, tf_graph)
     model_pb = load_model(model_path)
-    client.modelstore(
+    client.ai.modelstore(
         "m" + nonascii,
         "tf",
         "cpu",
@@ -342,10 +342,10 @@ def test_nonasciichar(client):
         outputs=["mul"],
         tag="v1.0",
     )
-    client.tensorset("a" + nonascii, (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
-    client.modelexecute("m" + nonascii, ["a" + nonascii, "b"], ["c" + nonascii])
-    tensor = client.tensorget("c" + nonascii)
+    client.ai.tensorset("a" + nonascii, (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
+    client.ai.modelexecute("m" + nonascii, ["a" + nonascii, "b"], ["c" + nonascii])
+    tensor = client.ai.tensorget("c" + nonascii)
     assert np.allclose(tensor, [4.0, 9.0])
 
 
@@ -358,38 +358,38 @@ def test_run_tf_model(client):
     model_pb = load_model(model_path)
     wrong_model_pb = load_model(bad_model_path)
 
-    client.modelstore(
+    client.ai.modelstore(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"], tag="v1.0"
     )
-    client.modeldel("m")
+    client.ai.modeldel("m")
     with pytest.raises(ResponseError):
-        client.modelget("m")
-    client.modelstore(
+        client.ai.modelget("m")
+    client.ai.modelstore(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs="mul", tag="v1.0"
     )
 
     # Required arguments ar None
     with pytest.raises(ValueError) as e:
-        client.modelexecute("m", inputs=None, outputs=None)
+        client.ai.modelexecute("m", inputs=None, outputs=None)
 
     # wrong model
     with pytest.raises(ResponseError) as e:
-        client.modelstore(
+        client.ai.modelstore(
             "m", "tf", "cpu", wrong_model_pb, inputs=["a", "b"], outputs=["mul"]
         )
 
-    client.tensorset("a", (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
-    client.modelexecute("m", ["a", "b"], ["c"])
-    tensor = client.tensorget("c")
+    client.ai.tensorset("a", (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
+    client.ai.modelexecute("m", ["a", "b"], ["c"])
+    tensor = client.ai.tensorget("c")
     assert np.allclose([4, 9], tensor)
-    model_det = client.modelget("m")
+    model_det = client.ai.modelget("m")
     assert model_det["backend"] == "TF"
     assert model_det["device"] == "cpu"  # TODO; RedisAI returns small letter
     assert model_det["tag"] == "v1.0"
-    client.modeldel("m")
+    client.ai.modeldel("m")
     with pytest.raises(ResponseError):
-        client.modelget("m")
+        client.ai.modelget("m")
 
 
 @pytest.mark.integrations
@@ -398,19 +398,19 @@ def test_run_tf_model(client):
 # and AI.SCRIPTSET is deprecated by AI.SCRIPTSTORE
 def test_deprecated_scriptset_and_scriptrun(client):
     with pytest.raises(ResponseError):
-        client.scriptset("scr", "cpu", "return 1")
-    client.scriptset("scr", "cpu", script_old)
-    client.tensorset("a", (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
+        client.ai.scriptset("scr", "cpu", "return 1")
+    client.ai.scriptset("scr", "cpu", script_old)
+    client.ai.tensorset("a", (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
 
     # test bar(a, b)
-    client.scriptrun("scr", "bar", inputs=["a", "b"], outputs=["c"])
-    tensor = client.tensorget("c", as_numpy=False)
+    client.ai.scriptrun("scr", "bar", inputs=["a", "b"], outputs=["c"])
+    tensor = client.ai.tensorget("c", as_numpy=False)
     assert [4, 6] == tensor["values"]
 
     # test bar_variadic(a, args : List[Tensor])
-    client.scriptrun("scr", "bar_variadic", inputs=["a", "$", "b", "b"], outputs=["c"])
-    tensor = client.tensorget("c", as_numpy=False)
+    client.ai.scriptrun("scr", "bar_variadic", inputs=["a", "$", "b", "b"], outputs=["c"])
+    tensor = client.ai.tensorget("c", as_numpy=False)
     assert [4, 6] == tensor["values"]
 
 
@@ -419,11 +419,11 @@ def test_deprecated_scriptset_and_scriptrun(client):
 def test_scriptstore(client):
     # try with bad arguments:
     with pytest.raises(ValueError):
-        client.scriptstore("test", "cpu", script, entry_points=None)
+        client.ai.scriptstore("test", "cpu", script, entry_points=None)
     with pytest.raises(ValueError):
-        client.scriptstore("test", "cpu", script=None, entry_points="bar")
+        client.ai.scriptstore("test", "cpu", script=None, entry_points="bar")
     with pytest.raises(ResponseError) as e:
-        client.scriptstore("test", "cpu", "return 1", "f")
+        client.ai.scriptstore("test", "cpu", "return 1", "f")
 
 
 @pytest.mark.integrations
@@ -431,67 +431,67 @@ def test_scriptstore(client):
 def test_scripts_execute(client):
     # try with bad arguments:
     with pytest.raises(ValueError):
-        client.scriptexecute("test", function=None, keys=None, inputs=None)
+        client.ai.scriptexecute("test", function=None, keys=None, inputs=None)
     with pytest.raises(ResponseError):
-        client.scriptexecute("test", "bar", inputs=["a"], outputs=["c"])
+        client.ai.scriptexecute("test", "bar", inputs=["a"], outputs=["c"])
 
-    client.scriptstore("test", "cpu", script, "bar")
-    client.tensorset("a", (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
-    client.scriptexecute("test", "bar", inputs=["a", "b"], outputs=["c"])
-    tensor = client.tensorget("c", as_numpy=False)
+    client.ai.scriptstore("test", "cpu", script, "bar")
+    client.ai.tensorset("a", (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
+    client.ai.scriptexecute("test", "bar", inputs=["a", "b"], outputs=["c"])
+    tensor = client.ai.tensorget("c", as_numpy=False)
     assert [4, 6] == tensor["values"]
-    script_det = client.scriptget("test")
+    script_det = client.ai.scriptget("test")
     assert script_det["device"] == "cpu"
     assert script_det["source"] == script
-    script_det = client.scriptget("test", meta_only=True)
+    script_det = client.ai.scriptget("test", meta_only=True)
     assert script_det["device"] == "cpu"
     assert "source" not in script_det
     # delete the script
-    client.scriptdel("test")
+    client.ai.scriptdel("test")
     with pytest.raises(ResponseError):
-        client.scriptget("test")
+        client.ai.scriptget("test")
 
     # store new script
-    client.scriptstore(
+    client.ai.scriptstore(
         "myscript{1}", "cpu", script, ["bar", "bar_variadic"], "version1"
     )
-    client.tensorset("a{1}", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.tensorset("b{1}", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.scriptexecute(
+    client.ai.tensorset("a{1}", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("b{1}", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.scriptexecute(
         "myscript{1}", "bar", inputs=["a{1}", "b{1}"], outputs=["c{1}"]
     )
-    values = client.tensorget("c{1}", as_numpy=False)
+    values = client.ai.tensorget("c{1}", as_numpy=False)
     assert np.allclose(values["values"], [4.0, 6.0, 4.0, 6.0])
 
-    client.tensorset("b1{1}", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.scriptexecute(
+    client.ai.tensorset("b1{1}", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.scriptexecute(
         "myscript{1}",
         "bar_variadic",
         inputs=["a{1}", "b1{1}", "b{1}"],
         outputs=["c{1}"],
     )
 
-    values = client.tensorget("c{1}", as_numpy=False)["values"]
+    values = client.ai.tensorget("c{1}", as_numpy=False)["values"]
     assert values == [4.0, 6.0, 4.0, 6.0]
 
 
 @pytest.mark.integrations
 @pytest.mark.ai
 def test_scripts_redis_commands(client):
-    client.scriptstore(
+    client.ai.scriptstore(
         "myscript{1}", "cpu", script_with_redis_commands, ["int_set_get", "func"]
     )
-    client.scriptexecute(
+    client.ai.scriptexecute(
         "myscript{1}", "int_set_get", keys=["x{1}", "{1}"], args=["3"], outputs=["y{1}"]
     )
-    values = client.tensorget("y{1}", as_numpy=False)
+    values = client.ai.tensorget("y{1}", as_numpy=False)
     assert np.allclose(values["values"], [3])
 
-    client.tensorset("mytensor1{1}", [40], dtype="float")
-    client.tensorset("mytensor2{1}", [10], dtype="float")
-    client.tensorset("mytensor3{1}", [1], dtype="float")
-    client.scriptexecute(
+    client.ai.tensorset("mytensor1{1}", [40], dtype="float")
+    client.ai.tensorset("mytensor2{1}", [10], dtype="float")
+    client.ai.tensorset("mytensor3{1}", [1], dtype="float")
+    client.ai.scriptexecute(
         "myscript{1}",
         "func",
         keys=["key{1}"],
@@ -499,7 +499,7 @@ def test_scripts_redis_commands(client):
         args=["3"],
         outputs=["my_output{1}"],
     )
-    values = client.tensorget("my_output{1}", as_numpy=False)
+    values = client.ai.tensorget("my_output{1}", as_numpy=False)
     assert np.allclose(values["values"], [54])
     assert client.get("key{1}") is None
 
@@ -509,12 +509,12 @@ def test_scripts_redis_commands(client):
 def test_run_onnxml_model(client):
     mlmodel_path = os.path.join(MODEL_DIR, "boston.onnx")
     onnxml_model = load_model(mlmodel_path)
-    client.modelstore("onnx_model", "onnx", "cpu", onnxml_model)
+    client.ai.modelstore("onnx_model", "onnx", "cpu", onnxml_model)
     tensor = np.ones((1, 13)).astype(np.float32)
-    client.tensorset("input", tensor)
-    client.modelexecute("onnx_model", ["input"], ["output"])
+    client.ai.tensorset("input", tensor)
+    client.ai.modelexecute("onnx_model", ["input"], ["output"])
     # tests `convert_to_num`
-    outtensor = client.tensorget("output", as_numpy=False)
+    outtensor = client.ai.tensorget("output", as_numpy=False)
     assert int(float(outtensor["values"][0])) == 24
 
 
@@ -525,11 +525,11 @@ def test_run_onnxdl_model(client):
     dlmodel_path = os.path.join(MODEL_DIR, "findsquare.onnx")
     onnxdl_model = load_model(dlmodel_path)
 
-    client.modelstore("onnx_model", "onnx", "cpu", onnxdl_model)
+    client.ai.modelstore("onnx_model", "onnx", "cpu", onnxdl_model)
     tensor = np.array((2,)).astype(np.float32)
-    client.tensorset("input", tensor)
-    client.modelexecute("onnx_model", ["input"], ["output"])
-    outtensor = client.tensorget("output")
+    client.ai.tensorset("input", tensor)
+    client.ai.modelexecute("onnx_model", ["input"], ["output"])
+    outtensor = client.ai.tensorget("output")
     assert np.allclose(outtensor, [4.0])
 
 
@@ -539,11 +539,11 @@ def test_run_pytorch_model(client):
     model_path = os.path.join(MODEL_DIR, torch_graph)
     ptmodel = load_model(model_path)
 
-    client.modelstore("pt_model", "torch", "cpu", ptmodel, tag="v1.0")
-    client.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.modelexecute("pt_model", ["a", "b"], ["output"])
-    output = client.tensorget("output", as_numpy=False)
+    client.ai.modelstore("pt_model", "torch", "cpu", ptmodel, tag="v1.0")
+    client.ai.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.modelexecute("pt_model", ["a", "b"], ["output"])
+    output = client.ai.tensorget("output", as_numpy=False)
     assert np.allclose(output["values"], [4, 6, 4, 6])
 
 
@@ -552,14 +552,14 @@ def test_run_pytorch_model(client):
 def test_run_tflite_model(client):
     model_path = os.path.join(MODEL_DIR, "mnist_model_quant.tflite")
     tflmodel = load_model(model_path)
-    client.modelstore("tfl_model", "tflite", "cpu", tflmodel)
+    client.ai.modelstore("tfl_model", "tflite", "cpu", tflmodel)
 
     input_path = os.path.join(TENSOR_DIR, "one.raw")
     with open(input_path, "rb") as f:
         img = np.frombuffer(f.read(), dtype=np.float32)
-    client.tensorset("img", img)
-    client.modelexecute("tfl_model", ["img"], ["output1", "output2"])
-    output = client.tensorget("output1")
+    client.ai.tensorset("img", img)
+    client.ai.modelexecute("tfl_model", ["img"], ["output1", "output2"])
+    output = client.ai.tensorget("output1")
     assert output == [1]
 
 
@@ -570,14 +570,14 @@ def test_deprecated_modelrun(client):
     model_path = os.path.join(MODEL_DIR, "graph.pb")
     model_pb = load_model(model_path)
 
-    client.modelstore(
+    client.ai.modelstore(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"], tag="v1.0"
     )
 
-    client.tensorset("a", (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
-    client.modelrun("m", ["a", "b"], ["c"])
-    tensor = client.tensorget("c")
+    client.ai.tensorset("a", (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
+    client.ai.modelrun("m", ["a", "b"], ["c"])
+    tensor = client.ai.tensorget("c")
     assert np.allclose([4, 9], tensor)
 
 
@@ -586,8 +586,8 @@ def test_deprecated_modelrun(client):
 def test_info(client):
     model_path = os.path.join(MODEL_DIR, tf_graph)
     model_pb = load_model(model_path)
-    client.modelstore("m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"])
-    first_info = client.infoget("m")
+    client.ai.modelstore("m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"])
+    first_info = client.ai.infoget("m")
     expected = {
         "key": "m",
         "type": "MODEL",
@@ -600,14 +600,14 @@ def test_info(client):
         "errors": 0,
     }
     assert first_info == expected
-    client.tensorset("a", (2, 3), dtype="float")
-    client.tensorset("b", (2, 3), dtype="float")
-    client.modelexecute("m", ["a", "b"], ["c"])
-    client.modelexecute("m", ["a", "b"], ["c"])
-    second_info = client.infoget("m")
+    client.ai.tensorset("a", (2, 3), dtype="float")
+    client.ai.tensorset("b", (2, 3), dtype="float")
+    client.ai.modelexecute("m", ["a", "b"], ["c"])
+    client.ai.modelexecute("m", ["a", "b"], ["c"])
+    second_info = client.ai.infoget("m")
     assert second_info["calls"] == 2  # 2 model runs
-    client.inforeset("m")
-    third_info = client.infoget("m")
+    client.ai.inforeset("m")
+    third_info = client.ai.infoget("m")
     # before modelrun and after reset
     assert first_info == third_info
 
@@ -617,7 +617,7 @@ def test_info(client):
 def test_model_scan(client):
     model_path = os.path.join(MODEL_DIR, tf_graph)
     model_pb = load_model(model_path)
-    client.modelstore(
+    client.ai.modelstore(
         "m", "tf", "cpu", model_pb, inputs=["a", "b"], outputs=["mul"], tag="v1.2"
     )
     model_path = os.path.join(MODEL_DIR, "pt-minimal.pt")
@@ -632,9 +632,9 @@ def test_model_scan(client):
 @pytest.mark.integrations
 @pytest.mark.ai
 def test_script_scan(client):
-    client.scriptset("ket1", "cpu", script, tag="v1.0")
-    client.scriptset("ket2", "cpu", script)
-    slist = client.scriptscan()
+    client.ai.scriptset("ket1", "cpu", script, tag="v1.0")
+    client.ai.scriptset("ket2", "cpu", script)
+    slist = client.ai.scriptscan()
     assert slist == [["ket1", "v1.0"], ["ket2", ""]]
 
 
@@ -645,7 +645,7 @@ def test_script_scan(client):
 def test_debug(client):
     client = get_client(debug=True)
     with Capturing() as output:
-        client.tensorset("x", (2, 3, 4, 5), dtype="float")
+        client.ai.tensorset("x", (2, 3, 4, 5), dtype="float")
     assert (["AI.TENSORSET x FLOAT 4 VALUES 2 3 4 5"] == output)
 """
 
@@ -656,7 +656,7 @@ def test_debug(client):
 @pytest.mark.ai
 def test_pipeline_non_transaction(client):
     arr = np.array([[2.0, 3.0], [2.0, 3.0]], dtype=np.float32)
-    pipe = client.pipeline(transaction=False)
+    pipe = client.ai.pipeline(transaction=False)
     pipe = pipe.tensorset("a", arr).set("native", 1)
     pipe = pipe.tensorget("a", as_numpy=False)
     pipe = pipe.tensorget("a", as_numpy=True).tensorget(
@@ -681,7 +681,7 @@ def test_pipeline_non_transaction(client):
 @pytest.mark.ai       
 def test_pipeline_transaction(client):
     arr = np.array([[2.0, 3.0], [2.0, 3.0]], dtype=np.float32)
-    pipe = client.pipeline(transaction=True)
+    pipe = client.ai.pipeline(transaction=True)
     pipe = pipe.tensorset("a", arr).set("native", 1)
     pipe = pipe.tensorget("a", as_numpy=False)
     pipe = pipe.tensorget("a", as_numpy=True).tensorget(

--- a/tests/test_aidag.py
+++ b/tests/test_aidag.py
@@ -117,7 +117,9 @@ def test_dagexecute_modelexecute_with_scriptexecute(client):
         data_processing_script,
         entry_points=["post_process", "pre_process_3ch"],
     )
-    client.ai.modelstore(model_name, "TF", "cpu", model, inputs="images", outputs="output")
+    client.ai.modelstore(
+        model_name, "TF", "cpu", model, inputs="images", outputs="output"
+    )
 
     dag = client.ai.dag(persist="output:{1}")
     dag.tensorset(

--- a/tests/test_aidag.py
+++ b/tests/test_aidag.py
@@ -23,7 +23,7 @@ def client():
     model_path = os.path.join(MODEL_DIR, torch_graph)
     ptmodel = load_model(model_path)
     rc.ai.modelstore("pt_model", "torch", "cpu", ptmodel, tag="v7.0")
-    return rc.ai
+    return rc
 
 
 @pytest.mark.integrations
@@ -33,7 +33,7 @@ def test_deprecated_dugrun(client):
     # test the warning of using dagrun
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("default")
-        dag = client.dag()
+        dag = client.ai.dag()
     assert issubclass(w[-1].category, DeprecationWarning)
 
     # test that dagrun and model run hadn't been broken
@@ -65,14 +65,14 @@ def test_deprecated_dugrun(client):
 @pytest.mark.aidag
 def test_deprecated_modelrun_and_run(client):
     # use modelrun&run method but perform modelexecute&dagexecute behind the scene
-    client.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    dag = client.dag(load=["a", "b"], persist="output")
+    client.ai.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    dag = client.ai.dag(load=["a", "b"], persist="output")
     dag.modelrun("pt_model", ["a", "b"], ["output"])
     dag.tensorget("output")
     result = dag.run()
     expected = ["OK", np.array([[4.0, 6.0], [4.0, 6.0]], dtype=np.float32)]
-    result_outside_dag = client.tensorget("output")
+    result_outside_dag = client.ai.tensorget("output")
     assert np.allclose(expected.pop(), result.pop())
     result = dag.run()
     assert np.allclose(result_outside_dag, result.pop())
@@ -83,8 +83,8 @@ def test_deprecated_modelrun_and_run(client):
 @pytest.mark.ai
 @pytest.mark.aidag
 def test_dagexecute_with_scriptexecute_redis_commands(client):
-    client.scriptstore("myscript{1}", "cpu", script_with_redis_commands, "func")
-    dag = client.dag(persist="my_output{1}", routing="{1}")
+    client.ai.scriptstore("myscript{1}", "cpu", script_with_redis_commands, "func")
+    dag = client.ai.dag(persist="my_output{1}", routing="{1}")
     dag.tensorset("mytensor1{1}", [40], dtype="float")
     dag.tensorset("mytensor2{1}", [10], dtype="float")
     dag.tensorset("mytensor3{1}", [1], dtype="float")
@@ -97,7 +97,7 @@ def test_dagexecute_with_scriptexecute_redis_commands(client):
         outputs=["my_output{1}"],
     )
     dag.execute()
-    values = client.tensorget("my_output{1}", as_numpy=False)
+    values = client.ai.tensorget("my_output{1}", as_numpy=False)
     assert np.allclose(values["values"], [54])
 
 
@@ -111,15 +111,15 @@ def test_dagexecute_modelexecute_with_scriptexecute(client):
     img = load_image()
     model_path = os.path.join(MODEL_DIR, "resnet50.pb")
     model = load_model(model_path)
-    client.scriptstore(
+    client.ai.scriptstore(
         script_name,
         "cpu",
         data_processing_script,
         entry_points=["post_process", "pre_process_3ch"],
     )
-    client.modelstore(model_name, "TF", "cpu", model, inputs="images", outputs="output")
+    client.ai.modelstore(model_name, "TF", "cpu", model, inputs="images", outputs="output")
 
-    dag = client.dag(persist="output:{1}")
+    dag = client.ai.dag(persist="output:{1}")
     dag.tensorset(
         "image:{1}", tensor=img, shape=(img.shape[1], img.shape[0]), dtype="UINT8"
     )
@@ -138,8 +138,8 @@ def test_dagexecute_modelexecute_with_scriptexecute(client):
 @pytest.mark.ai
 @pytest.mark.aidag
 def test_dagexecute_with_load(client):
-    client.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    dag = client.dag(load="a")
+    client.ai.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    dag = client.ai.dag(load="a")
     dag.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     dag.modelexecute("pt_model", ["a", "b"], ["output"])
     dag.tensorget("output")
@@ -147,7 +147,7 @@ def test_dagexecute_with_load(client):
     expected = ["OK", "OK", np.array([[4.0, 6.0], [4.0, 6.0]], dtype=np.float32)]
     assert np.allclose(expected.pop(), result.pop())
     assert expected == result
-    pytest.raises(ResponseError, client.tensorget, "b")
+    pytest.raises(ResponseError, client.ai.tensorget, "b")
 
 
 @pytest.mark.integrations
@@ -155,15 +155,15 @@ def test_dagexecute_with_load(client):
 @pytest.mark.aidag
 def test_dagexecute_with_persist(client):
     with pytest.raises(ResponseError):
-        dag = client.dag(persist="wrongkey")
+        dag = client.ai.dag(persist="wrongkey")
         dag.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float").execute()
 
-    dag = client.dag(persist=["b"])
+    dag = client.ai.dag(persist=["b"])
     dag.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     dag.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     dag.tensorget("b")
     result = dag.execute()
-    b = client.tensorget("b")
+    b = client.ai.tensorget("b")
     assert np.allclose(b, result[-1])
     assert b.dtype == np.float32
     assert len(result) == 3
@@ -173,9 +173,9 @@ def test_dagexecute_with_persist(client):
 @pytest.mark.ai
 @pytest.mark.aidag
 def test_dagexecute_calling_on_return(client):
-    client.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     result = (
-        client.dag(load="a")
+        client.ai.dag(load="a")
         .tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
         .modelexecute("pt_model", ["a", "b"], ["output"])
         .tensorget("output")
@@ -190,11 +190,11 @@ def test_dagexecute_calling_on_return(client):
 @pytest.mark.ai
 @pytest.mark.aidag
 def test_dagexecute_without_load_and_persist(client):
-    dag = client.dag(load="wrongkey")
+    dag = client.ai.dag(load="wrongkey")
     with pytest.raises(ResponseError):
         dag.tensorget("wrongkey").execute()
 
-    dag = client.dag(persist="output")
+    dag = client.ai.dag(persist="output")
     dag.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     dag.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     dag.modelexecute("pt_model", ["a", "b"], ["output"])
@@ -214,14 +214,14 @@ def test_dagexecute_without_load_and_persist(client):
 @pytest.mark.ai
 @pytest.mark.aidag
 def test_dagexecute_with_load_and_persist(client):
-    client.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    dag = client.dag(load=["a", "b"], persist="output")
+    client.ai.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    dag = client.ai.dag(load=["a", "b"], persist="output")
     dag.modelexecute("pt_model", ["a", "b"], ["output"])
     dag.tensorget("output")
     result = dag.execute()
     expected = ["OK", np.array([[4.0, 6.0], [4.0, 6.0]], dtype=np.float32)]
-    result_outside_dag = client.tensorget("output")
+    result_outside_dag = client.ai.tensorget("output")
     assert np.allclose(expected.pop(), result.pop())
     result = dag.execute()
     assert np.allclose(result_outside_dag, result.pop())
@@ -232,11 +232,11 @@ def test_dagexecute_with_load_and_persist(client):
 @pytest.mark.ai
 @pytest.mark.aidag
 def test_dagexecuteRO(client):
-    client.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
-    client.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("a", [2, 3, 2, 3], shape=(2, 2), dtype="float")
+    client.ai.tensorset("b", [2, 3, 2, 3], shape=(2, 2), dtype="float")
     with pytest.raises(RuntimeError):
-        client.dag(load=["a", "b"], persist="output", readonly=True)
-    dag = client.dag(load=["a", "b"], readonly=True)
+        client.ai.dag(load=["a", "b"], persist="output", readonly=True)
+    dag = client.ai.dag(load=["a", "b"], readonly=True)
 
     with pytest.raises(RuntimeError):
         dag.scriptexecute(

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -9,56 +9,56 @@ i = lambda l: [int(v) for v in l]
 @pytest.fixture
 def client():
     rc = Client(Redis())  # modules={'bf': {"client": Redis()}})
-    assert isinstance(rc.bloom, redisplus.bf.Bloom)
+    assert isinstance(rc.bf, redisplus.bf.Bloom)
     rc.flushdb()
 
-    return rc.bloom
+    return rc
 
 
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testCreate(client):
     """Test CREATE/RESERVE calls"""
-    assert client.bfcreate("bloom", 0.01, 1000)
-    assert client.bfcreate("bloom_e", 0.01, 1000, expansion=1)
-    assert client.bfcreate("bloom_ns", 0.01, 1000, noScale=True)
-    assert client.cfcreate("cuckoo", 1000)
-    assert client.cfcreate("cuckoo_e", 1000, expansion=1)
-    assert client.cfcreate("cuckoo_bs", 1000, bucket_size=4)
-    assert client.cfcreate("cuckoo_mi", 1000, max_iterations=10)
-    assert client.cmsinitbydim("cmsDim", 100, 5)
-    assert client.cmsinitbyprob("cmsProb", 0.01, 0.01)
-    assert client.topkreserve("topk", 5, 100, 5, 0.9)
-    assert client.tdigestcreate("tDigest", 100)
+    assert client.bf.bfcreate("bloom", 0.01, 1000)
+    assert client.bf.bfcreate("bloom_e", 0.01, 1000, expansion=1)
+    assert client.bf.bfcreate("bloom_ns", 0.01, 1000, noScale=True)
+    assert client.bf.cfcreate("cuckoo", 1000)
+    assert client.bf.cfcreate("cuckoo_e", 1000, expansion=1)
+    assert client.bf.cfcreate("cuckoo_bs", 1000, bucket_size=4)
+    assert client.bf.cfcreate("cuckoo_mi", 1000, max_iterations=10)
+    assert client.bf.cmsinitbydim("cmsDim", 100, 5)
+    assert client.bf.cmsinitbyprob("cmsProb", 0.01, 0.01)
+    assert client.bf.topkreserve("topk", 5, 100, 5, 0.9)
+    assert client.bf.tdigestcreate("tDigest", 100)
 
 
 # region Test Bloom Filter
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testBFAdd(client):
-    assert client.bfcreate("bloom", 0.01, 1000)
-    assert 1 == client.bfadd("bloom", "foo")
-    assert 0 == client.bfadd("bloom", "foo")
-    assert [0] == i(client.bfmadd("bloom", "foo"))
-    assert [0, 1] == client.bfmadd("bloom", "foo", "bar")
-    assert [0, 0, 1] == client.bfmadd("bloom", "foo", "bar", "baz")
-    assert 1 == client.bfexists("bloom", "foo")
-    assert 0 == client.bfexists("bloom", "noexist")
-    assert [1, 0] == i(client.bfmexists("bloom", "foo", "noexist"))
+    assert client.bf.bfcreate("bloom", 0.01, 1000)
+    assert 1 == client.bf.bfadd("bloom", "foo")
+    assert 0 == client.bf.bfadd("bloom", "foo")
+    assert [0] == i(client.bf.bfmadd("bloom", "foo"))
+    assert [0, 1] == client.bf.bfmadd("bloom", "foo", "bar")
+    assert [0, 0, 1] == client.bf.bfmadd("bloom", "foo", "bar", "baz")
+    assert 1 == client.bf.bfexists("bloom", "foo")
+    assert 0 == client.bf.bfexists("bloom", "noexist")
+    assert [1, 0] == i(client.bf.bfmexists("bloom", "foo", "noexist"))
 
 
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testBFInsert(client):
-    assert client.bfcreate("bloom", 0.01, 1000)
-    assert [1] == i(client.bfinsert("bloom", ["foo"]))
-    assert [0, 1] == i(client.bfinsert("bloom", ["foo", "bar"]))
-    assert [1] == i(client.bfinsert("captest", ["foo"], capacity=1000))
-    assert [1] == i(client.bfinsert("errtest", ["foo"], error=0.01))
-    assert 1 == client.bfexists("bloom", "foo")
-    assert 0 == client.bfexists("bloom", "noexist")
-    assert [1, 0] == i(client.bfmexists("bloom", "foo", "noexist"))
-    info = client.bfinfo("bloom")
+    assert client.bf.bfcreate("bloom", 0.01, 1000)
+    assert [1] == i(client.bf.bfinsert("bloom", ["foo"]))
+    assert [0, 1] == i(client.bf.bfinsert("bloom", ["foo", "bar"]))
+    assert [1] == i(client.bf.bfinsert("captest", ["foo"], capacity=1000))
+    assert [1] == i(client.bf.bfinsert("errtest", ["foo"], error=0.01))
+    assert 1 == client.bf.bfexists("bloom", "foo")
+    assert 0 == client.bf.bfexists("bloom", "noexist")
+    assert [1, 0] == i(client.bf.bfmexists("bloom", "foo", "noexist"))
+    info = client.bf.bfinfo("bloom")
     assert 2 == info.insertedNum
     assert 1000 == info.capacity
     assert 1 == info.filterNum
@@ -68,48 +68,48 @@ def testBFInsert(client):
 @pytest.mark.bloom
 def testBFDumpLoad(client):
     # Store a filter
-    client.bfcreate("myBloom", "0.0001", "1000")
+    client.bf.bfcreate("myBloom", "0.0001", "1000")
 
     # test is probabilistic and might fail. It is OK to change variables if
     # certain to not break anything
     def do_verify():
         res = 0
         for x in range(1000):
-            client.bfadd("myBloom", x)
-            rv = client.bfexists("myBloom", x)
+            client.bf.bfadd("myBloom", x)
+            rv = client.bf.bfexists("myBloom", x)
             assert rv
-            rv = client.bfexists("myBloom", "nonexist_{}".format(x))
+            rv = client.bf.bfexists("myBloom", "nonexist_{}".format(x))
             res += rv == x
         assert res < 5
 
     do_verify()
     cmds = []
-    cur = client.bfscandump("myBloom", 0)
+    cur = client.bf.bfscandump("myBloom", 0)
     first = cur[0]
     cmds.append(cur)
 
     while True:
-        cur = client.bfscandump("myBloom", first)
+        cur = client.bf.bfscandump("myBloom", first)
         first = cur[0]
         if first == 0:
             break
         else:
             cmds.append(cur)
-    prev_info = client.execute_command("bf.debug", "myBloom")
+    prev_info = client.bf.execute_command("bf.debug", "myBloom")
 
     # Remove the filter
-    client.execute_command("del", "myBloom")
+    client.bf.execute_command("del", "myBloom")
 
     # Now, load all the commands:
     for cmd in cmds:
-        client.bfloadchunk("myBloom", *cmd)
+        client.bf.bfloadchunk("myBloom", *cmd)
 
-    cur_info = client.execute_command("bf.debug", "myBloom")
+    cur_info = client.bf.execute_command("bf.debug", "myBloom")
     assert prev_info == cur_info
     do_verify()
 
-    client.execute_command("del", "myBloom")
-    client.bfcreate("myBloom", "0.0001", "10000000")
+    client.bf.execute_command("del", "myBloom")
+    client.bf.bfcreate("myBloom", "0.0001", "10000000")
 
 
 @pytest.mark.integrations
@@ -117,17 +117,17 @@ def testBFDumpLoad(client):
 def testBFInfo(client):
     expansion = 4
     # Store a filter
-    client.bfcreate("nonscaling", "0.0001", "1000", noScale=True)
-    info = client.bfinfo("nonscaling")
+    client.bf.bfcreate("nonscaling", "0.0001", "1000", noScale=True)
+    info = client.bf.bfinfo("nonscaling")
     assert info.expansionRate is None
 
-    client.bfcreate("expanding", "0.0001", "1000", expansion=expansion)
-    info = client.bfinfo("expanding")
+    client.bf.bfcreate("expanding", "0.0001", "1000", expansion=expansion)
+    info = client.bf.bfinfo("expanding")
     assert info.expansionRate == 4
 
     try:
         # noScale mean no expansion
-        client.bfcreate("myBloom", "0.0001", "1000", expansion=expansion, noScale=True)
+        client.bf.bfcreate("myBloom", "0.0001", "1000", expansion=expansion, noScale=True)
         assert False
     except:
         assert True
@@ -140,19 +140,19 @@ def testBFInfo(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testCFAddInsert(client):
-    assert client.cfcreate("cuckoo", 1000)
-    assert client.cfadd("cuckoo", "filter")
-    assert not client.cfaddnx("cuckoo", "filter")
-    assert 1 == client.cfaddnx("cuckoo", "newItem")
-    assert [1] == client.cfinsert("captest", ["foo"])
-    assert [1] == client.cfinsert("captest", ["foo"], capacity=1000)
-    assert [1] == client.cfinsertnx("captest", ["bar"])
-    assert [1] == client.cfinsertnx("captest", ["food"], nocreate="1")
-    assert [0, 0, 1] == client.cfinsertnx("captest", ["foo", "bar", "baz"])
-    assert [0] == client.cfinsertnx("captest", ["bar"], capacity=1000)
-    assert [1] == client.cfinsert("empty1", ["foo"], capacity=1000)
-    assert [1] == client.cfinsertnx("empty2", ["bar"], capacity=1000)
-    info = client.cfinfo("captest")
+    assert client.bf.cfcreate("cuckoo", 1000)
+    assert client.bf.cfadd("cuckoo", "filter")
+    assert not client.bf.cfaddnx("cuckoo", "filter")
+    assert 1 == client.bf.cfaddnx("cuckoo", "newItem")
+    assert [1] == client.bf.cfinsert("captest", ["foo"])
+    assert [1] == client.bf.cfinsert("captest", ["foo"], capacity=1000)
+    assert [1] == client.bf.cfinsertnx("captest", ["bar"])
+    assert [1] == client.bf.cfinsertnx("captest", ["food"], nocreate="1")
+    assert [0, 0, 1] == client.bf.cfinsertnx("captest", ["foo", "bar", "baz"])
+    assert [0] == client.bf.cfinsertnx("captest", ["bar"], capacity=1000)
+    assert [1] == client.bf.cfinsert("empty1", ["foo"], capacity=1000)
+    assert [1] == client.bf.cfinsertnx("empty2", ["bar"], capacity=1000)
+    info = client.bf.cfinfo("captest")
     assert 5 == info.insertedNum
     assert 0 == info.deletedNum
     assert 1 == info.filterNum
@@ -161,14 +161,14 @@ def testCFAddInsert(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testCFExistsDel(client):
-    assert client.cfcreate("cuckoo", 1000)
-    assert client.cfadd("cuckoo", "filter")
-    assert client.cfexists("cuckoo", "filter")
-    assert not client.cfexists("cuckoo", "notexist")
-    assert 1 == client.cfcount("cuckoo", "filter")
-    assert 0 == client.cfcount("cuckoo", "notexist")
-    assert client.cfdel("cuckoo", "filter")
-    assert 0 == client.cfcount("cuckoo", "filter")
+    assert client.bf.cfcreate("cuckoo", 1000)
+    assert client.bf.cfadd("cuckoo", "filter")
+    assert client.bf.cfexists("cuckoo", "filter")
+    assert not client.bf.cfexists("cuckoo", "notexist")
+    assert 1 == client.bf.cfcount("cuckoo", "filter")
+    assert 0 == client.bf.cfcount("cuckoo", "notexist")
+    assert client.bf.cfdel("cuckoo", "filter")
+    assert 0 == client.bf.cfcount("cuckoo", "filter")
 
 
 # endregion
@@ -178,14 +178,14 @@ def testCFExistsDel(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testCMS(client):
-    assert client.cmsinitbydim("dim", 1000, 5)
-    assert client.cmsinitbyprob("prob", 0.01, 0.01)
-    assert client.cmsincrby("dim", ["foo"], [5])
-    assert [0] == client.cmsquery("dim", "notexist")
-    assert [5] == client.cmsquery("dim", "foo")
-    assert [10, 15] == client.cmsincrby("dim", ["foo", "bar"], [5, 15])
-    assert [10, 15] == client.cmsquery("dim", "foo", "bar")
-    info = client.cmsinfo("dim")
+    assert client.bf.cmsinitbydim("dim", 1000, 5)
+    assert client.bf.cmsinitbyprob("prob", 0.01, 0.01)
+    assert client.bf.cmsincrby("dim", ["foo"], [5])
+    assert [0] == client.bf.cmsquery("dim", "notexist")
+    assert [5] == client.bf.cmsquery("dim", "foo")
+    assert [10, 15] == client.bf.cmsincrby("dim", ["foo", "bar"], [5, 15])
+    assert [10, 15] == client.bf.cmsquery("dim", "foo", "bar")
+    info = client.bf.cmsinfo("dim")
     assert 1000 == info.width
     assert 5 == info.depth
     assert 25 == info.count
@@ -194,19 +194,19 @@ def testCMS(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testCMSMerge(client):
-    assert client.cmsinitbydim("A", 1000, 5)
-    assert client.cmsinitbydim("B", 1000, 5)
-    assert client.cmsinitbydim("C", 1000, 5)
-    assert client.cmsincrby("A", ["foo", "bar", "baz"], [5, 3, 9])
-    assert client.cmsincrby("B", ["foo", "bar", "baz"], [2, 3, 1])
-    assert [5, 3, 9] == client.cmsquery("A", "foo", "bar", "baz")
-    assert [2, 3, 1] == client.cmsquery("B", "foo", "bar", "baz")
-    assert client.cmsmerge("C", 2, ["A", "B"])
-    assert [7, 6, 10] == client.cmsquery("C", "foo", "bar", "baz")
-    assert client.cmsmerge("C", 2, ["A", "B"], ["1", "2"])
-    assert [9, 9, 11] == client.cmsquery("C", "foo", "bar", "baz")
-    assert client.cmsmerge("C", 2, ["A", "B"], ["2", "3"])
-    assert [16, 15, 21] == client.cmsquery("C", "foo", "bar", "baz")
+    assert client.bf.cmsinitbydim("A", 1000, 5)
+    assert client.bf.cmsinitbydim("B", 1000, 5)
+    assert client.bf.cmsinitbydim("C", 1000, 5)
+    assert client.bf.cmsincrby("A", ["foo", "bar", "baz"], [5, 3, 9])
+    assert client.bf.cmsincrby("B", ["foo", "bar", "baz"], [2, 3, 1])
+    assert [5, 3, 9] == client.bf.cmsquery("A", "foo", "bar", "baz")
+    assert [2, 3, 1] == client.bf.cmsquery("B", "foo", "bar", "baz")
+    assert client.bf.cmsmerge("C", 2, ["A", "B"])
+    assert [7, 6, 10] == client.bf.cmsquery("C", "foo", "bar", "baz")
+    assert client.bf.cmsmerge("C", 2, ["A", "B"], ["1", "2"])
+    assert [9, 9, 11] == client.bf.cmsquery("C", "foo", "bar", "baz")
+    assert client.bf.cmsmerge("C", 2, ["A", "B"], ["2", "3"])
+    assert [16, 15, 21] == client.bf.cmsquery("C", "foo", "bar", "baz")
 
 
 # endregion
@@ -217,7 +217,7 @@ def testCMSMerge(client):
 @pytest.mark.bloom
 def testTopK(client):
     # test list with empty buckets
-    assert client.topkreserve("topk", 3, 50, 4, 0.9)
+    assert client.bf.topkreserve("topk", 3, 50, 4, 0.9)
     assert [
         None,
         None,
@@ -236,7 +236,7 @@ def testTopK(client):
         None,
         None,
         None,
-    ] == client.topkadd(
+    ] == client.bf.topkadd(
         "topk",
         "A",
         "B",
@@ -256,16 +256,16 @@ def testTopK(client):
         "E",
         1,
     )
-    assert [1, 1, 0, 1, 0, 0, 0] == client.topkquery(
+    assert [1, 1, 0, 1, 0, 0, 0] == client.bf.topkquery(
         "topk", "A", "B", "C", "D", "E", "F", "G"
     )
-    assert [4, 3, 2, 3, 3, 0, 1] == client.topkcount(
+    assert [4, 3, 2, 3, 3, 0, 1] == client.bf.topkcount(
         "topk", "A", "B", "C", "D", "E", "F", "G"
     )
 
     # test full list
-    assert client.topkreserve("topklist", 3, 50, 3, 0.9)
-    assert client.topkadd(
+    assert client.bf.topkreserve("topklist", 3, 50, 3, 0.9)
+    assert client.bf.topkadd(
         "topklist",
         "A",
         "B",
@@ -284,8 +284,8 @@ def testTopK(client):
         "E",
         "E",
     )
-    assert ["D", "A", "B"] == client.topklist("topklist")
-    info = client.topkinfo("topklist")
+    assert ["D", "A", "B"] == client.bf.topklist("topklist")
+    info = client.bf.topkinfo("topklist")
     assert 3 == info.k
     assert 50 == info.width
     assert 3 == info.depth
@@ -299,29 +299,29 @@ def testTopK(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testTDigestReset(client):
-    assert client.tdigestcreate("tDigest", 10)
+    assert client.bf.tdigestcreate("tDigest", 10)
     # reset on empty histogram
-    assert client.tdigestreset("tDigest")
+    assert client.bf.tdigestreset("tDigest")
     # insert data-points into sketch
-    assert client.tdigestadd("tDigest", list(range(10)), [1.0] * 10)
+    assert client.bf.tdigestadd("tDigest", list(range(10)), [1.0] * 10)
 
-    assert client.tdigestreset("tDigest")
+    assert client.bf.tdigestreset("tDigest")
     # assert we have 0 unmerged nodes
-    assert 0 == client.tdigestinfo("tDigest").unmergedNodes
+    assert 0 == client.bf.tdigestinfo("tDigest").unmergedNodes
 
 
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testTDigestMerge(client):
-    assert client.tdigestcreate("to-tDigest", 10)
-    assert client.tdigestcreate("from-tDigest", 10)
+    assert client.bf.tdigestcreate("to-tDigest", 10)
+    assert client.bf.tdigestcreate("from-tDigest", 10)
     # insert data-points into sketch
-    assert client.tdigestadd("from-tDigest", [1.0] * 10, [1.0] * 10)
-    assert client.tdigestadd("to-tDigest", [2.0] * 10, [10.0] * 10)
+    assert client.bf.tdigestadd("from-tDigest", [1.0] * 10, [1.0] * 10)
+    assert client.bf.tdigestadd("to-tDigest", [2.0] * 10, [10.0] * 10)
     # merge from-tdigest into to-tdigest
-    assert client.tdigestmerge("to-tDigest", "from-tDigest")
+    assert client.bf.tdigestmerge("to-tDigest", "from-tDigest")
     # we should now have 110 weight on to-histogram
-    info = client.tdigestinfo("to-tDigest")
+    info = client.bf.tdigestinfo("to-tDigest")
     total_weight_to = float(info.mergedWeight) + float(info.unmergedWeight)
     assert 110 == total_weight_to
 
@@ -329,39 +329,39 @@ def testTDigestMerge(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testTDigestMinMax(client):
-    assert client.tdigestcreate("tDigest", 100)
+    assert client.bf.tdigestcreate("tDigest", 100)
     # insert data-points into sketch
-    assert client.tdigestadd("tDigest", [1, 2, 3], [1.0] * 3)
+    assert client.bf.tdigestadd("tDigest", [1, 2, 3], [1.0] * 3)
     # min/max
-    assert 3 == client.tdigestmax("tDigest")
-    assert 1 == client.tdigestmin("tDigest")
+    assert 3 == client.bf.tdigestmax("tDigest")
+    assert 1 == client.bf.tdigestmin("tDigest")
 
 
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testTDigestQuantile(client):
-    assert client.tdigestcreate("tDigest", 500)
+    assert client.bf.tdigestcreate("tDigest", 500)
     # insert data-points into sketch
-    assert client.tdigestadd(
+    assert client.bf.tdigestadd(
         "tDigest", list([x * 0.01 for x in range(1, 10000)]), [1.0] * 10000
     )
     # assert min min/max have same result as quantile 0 and 1
-    assert client.tdigestmax("tDigest") == client.tdigestquantile("tDigest", 1.0)
-    assert client.tdigestmin("tDigest") == client.tdigestquantile("tDigest", 0.0)
+    assert client.bf.tdigestmax("tDigest") == client.bf.tdigestquantile("tDigest", 1.0)
+    assert client.bf.tdigestmin("tDigest") == client.bf.tdigestquantile("tDigest", 0.0)
 
-    assert 1.0 == round(client.tdigestquantile("tDigest", 0.01), 2)
-    assert 99.0 == round(client.tdigestquantile("tDigest", 0.99), 2)
+    assert 1.0 == round(client.bf.tdigestquantile("tDigest", 0.01), 2)
+    assert 99.0 == round(client.bf.tdigestquantile("tDigest", 0.99), 2)
 
 
 @pytest.mark.integrations
 @pytest.mark.bloom
 def testTDigestCdf(client):
-    assert client.tdigestcreate("tDigest", 100)
+    assert client.bf.tdigestcreate("tDigest", 100)
     # insert data-points into sketch
-    assert client.tdigestadd("tDigest", list(range(1, 10)), [1.0] * 10)
+    assert client.bf.tdigestadd("tDigest", list(range(1, 10)), [1.0] * 10)
 
-    assert 0.1 == round(client.tdigestcdf("tDigest", 1.0), 1)
-    assert 0.9 == round(client.tdigestcdf("tDigest", 9.0), 1)
+    assert 0.1 == round(client.bf.tdigestcdf("tDigest", 1.0), 1)
+    assert 0.9 == round(client.bf.tdigestcdf("tDigest", 9.0), 1)
 
 
 # endregion
@@ -370,17 +370,16 @@ def testTDigestCdf(client):
 @pytest.mark.integrations
 @pytest.mark.bloom
 def test_pipeline(client):
-    pipeline = client.pipeline()
+    pipeline = client.bf.pipeline()
+    assert not client.bf.execute_command("get pipeline")
 
-    assert not client.execute_command("get pipeline")
-
-    assert client.bfcreate("pipeline", 0.01, 1000)
+    assert client.bf.bfcreate("pipeline", 0.01, 1000)
     for i in range(100):
         pipeline.bfadd("pipeline", i)
     for i in range(100):
-        assert not (client.bfexists("pipeline", i))
+        assert not (client.bf.bfexists("pipeline", i))
 
     pipeline.execute()
 
     for i in range(100):
-        assert client.bfexists("pipeline", i)
+        assert client.bf.bfexists("pipeline", i)

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -127,7 +127,9 @@ def testBFInfo(client):
 
     try:
         # noScale mean no expansion
-        client.bf.bfcreate("myBloom", "0.0001", "1000", expansion=expansion, noScale=True)
+        client.bf.bfcreate(
+            "myBloom", "0.0001", "1000", expansion=expansion, noScale=True
+        )
         assert False
     except:
         assert True

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -12,71 +12,71 @@ def client():
     rc = Client(Redis())
     assert isinstance(rc.json, redisplus.json.JSON)
     rc.flushdb()
-    return rc.json
+    return rc
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_json_setgetdeleteforget(client):
-    assert client.jsonset("foo", Path.rootPath(), "bar")
-    assert client.jsonget("foo") == "bar"
-    assert client.jsonget("baz") is None
-    assert client.jsondel("foo") == 1
-    assert client.jsonforget("foo") == 0  # second delete
-    assert client.client.exists("foo") == 0
+    assert client.json.jsonset("foo", Path.rootPath(), "bar")
+    assert client.json.jsonget("foo") == "bar"
+    assert client.json.jsonget("baz") is None
+    assert client.json.jsondel("foo") == 1
+    assert client.json.jsonforget("foo") == 0  # second delete
+    assert client.exists("foo") == 0
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_justaget(client):
-    client.jsonset("foo", Path.rootPath(), "bar")
-    assert client.jsonget("foo") == "bar"
+    client.json.jsonset("foo", Path.rootPath(), "bar")
+    assert client.json.jsonget("foo") == "bar"
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_json_get_jset(client):
-    assert client.jsonset("foo", Path.rootPath(), "bar")
-    assert "bar" == client.jsonget("foo")
-    assert None == client.jsonget("baz")
-    assert 1 == client.jsondel("foo")
-    assert client.client.exists("foo") == 0
+    assert client.json.jsonset("foo", Path.rootPath(), "bar")
+    assert "bar" == client.json.jsonget("foo")
+    assert None == client.json.jsonget("baz")
+    assert 1 == client.json.jsondel("foo")
+    assert client.exists("foo") == 0
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_nonascii_setgetdelete(client):
-    assert client.jsonset("notascii", Path.rootPath(), "hyvää-élève") is True
-    assert "hyvää-élève" == client.jsonget("notascii", no_escape=True)
-    assert 1 == client.jsondel("notascii")
-    assert client.client.exists("notascii") == 0
+    assert client.json.jsonset("notascii", Path.rootPath(), "hyvää-élève") is True
+    assert "hyvää-élève" == client.json.jsonget("notascii", no_escape=True)
+    assert 1 == client.json.jsondel("notascii")
+    assert client.exists("notascii") == 0
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_jsonsetexistentialmodifiersshouldsucceed(client):
     obj = {"foo": "bar"}
-    assert client.jsonset("obj", Path.rootPath(), obj)
+    assert client.json.jsonset("obj", Path.rootPath(), obj)
 
     # Test that flags prevent updates when conditions are unmet
-    assert client.jsonset("obj", Path("foo"), "baz", nx=True) is None
-    assert client.jsonset("obj", Path("qaz"), "baz", xx=True) is None
+    assert client.json.jsonset("obj", Path("foo"), "baz", nx=True) is None
+    assert client.json.jsonset("obj", Path("qaz"), "baz", xx=True) is None
 
     # Test that flags allow updates when conditions are met
-    assert client.jsonset("obj", Path("foo"), "baz", xx=True)
-    assert client.jsonset("obj", Path("qaz"), "baz", nx=True)
+    assert client.json.jsonset("obj", Path("foo"), "baz", xx=True)
+    assert client.json.jsonset("obj", Path("qaz"), "baz", nx=True)
 
     # Test that flags are mutually exlusive
     with pytest.raises(Exception):
-        client.jsonset("obj", Path("foo"), "baz", nx=True, xx=True)
+        client.json.jsonset("obj", Path("foo"), "baz", nx=True, xx=True)
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_mgetshouldsucceed(client):
-    client.jsonset("1", Path.rootPath(), 1)
-    client.jsonset("2", Path.rootPath(), 2)
-    r = client.jsonmget(Path.rootPath(), "1", "2")
+    client.json.jsonset("1", Path.rootPath(), 1)
+    client.json.jsonset("2", Path.rootPath(), 2)
+    r = client.json.jsonmget(Path.rootPath(), "1", "2")
     e = [1, 2]
     assert e == r
 
@@ -85,97 +85,97 @@ def test_mgetshouldsucceed(client):
 @pytest.mark.json
 @skip_ifmodversion_lt("99.99.99", "ReJSON")  # todo: update after the release
 def test_clearShouldSucceed(client):
-    client.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
-    assert 1 == client.jsonclear("arr", Path.rootPath())
-    assert [] == client.jsonget("arr")
+    client.json.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
+    assert 1 == client.json.jsonclear("arr", Path.rootPath())
+    assert [] == client.json.jsonget("arr")
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_typeshouldsucceed(client):
-    client.jsonset("1", Path.rootPath(), 1)
-    assert b"integer" == client.jsontype("1")
+    client.json.jsonset("1", Path.rootPath(), 1)
+    assert b"integer" == client.json.jsontype("1")
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_numincrbyshouldsucceed(client):
-    client.jsonset("num", Path.rootPath(), 1)
-    assert 2 == client.jsonnumincrby("num", Path.rootPath(), 1)
-    assert 2.5 == client.jsonnumincrby("num", Path.rootPath(), 0.5)
-    assert 1.25 == client.jsonnumincrby("num", Path.rootPath(), -1.25)
+    client.json.jsonset("num", Path.rootPath(), 1)
+    assert 2 == client.json.jsonnumincrby("num", Path.rootPath(), 1)
+    assert 2.5 == client.json.jsonnumincrby("num", Path.rootPath(), 0.5)
+    assert 1.25 == client.json.jsonnumincrby("num", Path.rootPath(), -1.25)
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_nummultbyshouldsucceed(client):
-    client.jsonset("num", Path.rootPath(), 1)
-    assert 2 == client.jsonnummultby("num", Path.rootPath(), 2)
-    assert 5 == client.jsonnummultby("num", Path.rootPath(), 2.5)
-    assert 2.5 == client.jsonnummultby("num", Path.rootPath(), 0.5)
+    client.json.jsonset("num", Path.rootPath(), 1)
+    assert 2 == client.json.jsonnummultby("num", Path.rootPath(), 2)
+    assert 5 == client.json.jsonnummultby("num", Path.rootPath(), 2.5)
+    assert 2.5 == client.json.jsonnummultby("num", Path.rootPath(), 0.5)
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 @skip_ifmodversion_lt("99.99.99", "ReJSON")  # todo: update after the release
 def test_toggleShouldSucceed(client):
-    client.jsonset("bool", Path.rootPath(), False)
-    print(client.jsontoggle("bool", Path.rootPath()))
-    print(client.jsontoggle("bool", Path.rootPath()))
-    assert client.jsontoggle("bool", Path.rootPath())
-    assert not client.jsontoggle("bool", Path.rootPath())
+    client.json.jsonset("bool", Path.rootPath(), False)
+    print(client.json.jsontoggle("bool", Path.rootPath()))
+    print(client.json.jsontoggle("bool", Path.rootPath()))
+    assert client.json.jsontoggle("bool", Path.rootPath())
+    assert not client.json.jsontoggle("bool", Path.rootPath())
     # check non-boolean value
-    client.jsonset("num", Path.rootPath(), 1)
+    client.json.jsonset("num", Path.rootPath(), 1)
     with pytest.raises(redis.exceptions.ResponseError):
-        client.jsontoggle("num", Path.rootPath())
+        client.json.jsontoggle("num", Path.rootPath())
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_strappendshouldsucceed(client):
-    client.jsonset("str", Path.rootPath(), "foo")
-    assert 6 == client.jsonstrappend("str", "bar", Path.rootPath())
-    assert "foobar" == client.jsonget("str", Path.rootPath())
+    client.json.jsonset("str", Path.rootPath(), "foo")
+    assert 6 == client.json.jsonstrappend("str", "bar", Path.rootPath())
+    assert "foobar" == client.json.jsonget("str", Path.rootPath())
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_debug(client):
-    client.jsonset("str", Path.rootPath(), "foo")
-    assert 24 == client.jsondebug("str", Path.rootPath())
+    client.json.jsonset("str", Path.rootPath(), "foo")
+    assert 24 == client.json.jsondebug("str", Path.rootPath())
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_strlenshouldsucceed(client):
-    client.jsonset("str", Path.rootPath(), "foo")
-    assert 3 == client.jsonstrlen("str", Path.rootPath())
-    client.jsonstrappend("str", "bar", Path.rootPath())
-    assert 6 == client.jsonstrlen("str", Path.rootPath())
+    client.json.jsonset("str", Path.rootPath(), "foo")
+    assert 3 == client.json.jsonstrlen("str", Path.rootPath())
+    client.json.jsonstrappend("str", "bar", Path.rootPath())
+    assert 6 == client.json.jsonstrlen("str", Path.rootPath())
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_arrappendshouldsucceed(client):
-    client.jsonset("arr", Path.rootPath(), [1])
-    assert 2 == client.jsonarrappend("arr", Path.rootPath(), 2)
-    assert 4 == client.jsonarrappend("arr", Path.rootPath(), 3, 4)
-    assert 7 == client.jsonarrappend("arr", Path.rootPath(), *[5, 6, 7])
+    client.json.jsonset("arr", Path.rootPath(), [1])
+    assert 2 == client.json.jsonarrappend("arr", Path.rootPath(), 2)
+    assert 4 == client.json.jsonarrappend("arr", Path.rootPath(), 3, 4)
+    assert 7 == client.json.jsonarrappend("arr", Path.rootPath(), *[5, 6, 7])
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def testArrIndexShouldSucceed(client):
-    client.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
-    assert 1 == client.jsonarrindex("arr", Path.rootPath(), 1)
-    assert -1 == client.jsonarrindex("arr", Path.rootPath(), 1, 2)
+    client.json.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
+    assert 1 == client.json.jsonarrindex("arr", Path.rootPath(), 1)
+    assert -1 == client.json.jsonarrindex("arr", Path.rootPath(), 1, 2)
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_arrinsertshouldsucceed(client):
-    client.jsonset("arr", Path.rootPath(), [0, 4])
-    assert 5 - -client.jsonarrinsert(
+    client.json.jsonset("arr", Path.rootPath(), [0, 4])
+    assert 5 - -client.json.jsonarrinsert(
         "arr",
         Path.rootPath(),
         1,
@@ -185,51 +185,51 @@ def test_arrinsertshouldsucceed(client):
             3,
         ]
     )
-    assert [0, 1, 2, 3, 4] == client.jsonget("arr")
+    assert [0, 1, 2, 3, 4] == client.json.jsonget("arr")
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_arrlenshouldsucceed(client):
-    client.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
-    assert 5 == client.jsonarrlen("arr", Path.rootPath())
+    client.json.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
+    assert 5 == client.json.jsonarrlen("arr", Path.rootPath())
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_arrpopshouldsucceed(client):
-    client.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
-    assert 4 == client.jsonarrpop("arr", Path.rootPath(), 4)
-    assert 3 == client.jsonarrpop("arr", Path.rootPath(), -1)
-    assert 2 == client.jsonarrpop("arr", Path.rootPath())
-    assert 0 == client.jsonarrpop("arr", Path.rootPath(), 0)
-    assert [1] == client.jsonget("arr")
+    client.json.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
+    assert 4 == client.json.jsonarrpop("arr", Path.rootPath(), 4)
+    assert 3 == client.json.jsonarrpop("arr", Path.rootPath(), -1)
+    assert 2 == client.json.jsonarrpop("arr", Path.rootPath())
+    assert 0 == client.json.jsonarrpop("arr", Path.rootPath(), 0)
+    assert [1] == client.json.jsonget("arr")
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_arrtrimshouldsucceed(client):
-    client.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
-    assert 3 == client.jsonarrtrim("arr", Path.rootPath(), 1, 3)
-    assert [1, 2, 3] == client.jsonget("arr")
+    client.json.jsonset("arr", Path.rootPath(), [0, 1, 2, 3, 4])
+    assert 3 == client.json.jsonarrtrim("arr", Path.rootPath(), 1, 3)
+    assert [1, 2, 3] == client.json.jsonget("arr")
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_respshouldsucceed(client):
     obj = {"foo": "bar", "baz": 1, "qaz": True}
-    client.jsonset("obj", Path.rootPath(), obj)
-    assert b"bar" == client.jsonresp("obj", Path("foo"))
-    assert 1 == client.jsonresp("obj", Path("baz"))
-    assert client.jsonresp("obj", Path("qaz"))
+    client.json.jsonset("obj", Path.rootPath(), obj)
+    assert b"bar" == client.json.jsonresp("obj", Path("foo"))
+    assert 1 == client.json.jsonresp("obj", Path("baz"))
+    assert client.json.jsonresp("obj", Path("qaz"))
 
 
 @pytest.mark.integrations
 @pytest.mark.json
 def test_objkeysshouldsucceed(client):
     obj = {"foo": "bar", "baz": "qaz"}
-    client.jsonset("obj", Path.rootPath(), obj)
-    keys = client.jsonobjkeys("obj", Path.rootPath())
+    client.json.jsonset("obj", Path.rootPath(), obj)
+    keys = client.json.jsonobjkeys("obj", Path.rootPath())
     keys.sort()
     exp = list(obj.keys())
     exp.sort()
@@ -240,17 +240,17 @@ def test_objkeysshouldsucceed(client):
 @pytest.mark.json
 def test_objlenshouldsucceed(client):
     obj = {"foo": "bar", "baz": "qaz"}
-    client.jsonset("obj", Path.rootPath(), obj)
-    assert len(obj) == client.jsonobjlen("obj", Path.rootPath())
+    client.json.jsonset("obj", Path.rootPath(), obj)
+    assert len(obj) == client.json.jsonobjlen("obj", Path.rootPath())
 
 
 @pytest.mark.integrations
 @pytest.mark.pipeline
 @pytest.mark.json
 def test_pipelineshouldsucceed(client):
-    p = client.pipeline()
+    p = client.json.pipeline()
     p.jsonset("foo", Path.rootPath(), "bar")
     p.jsonget("foo")
     p.jsondel("foo")
-    p.exists("foo")
-    assert [True, "bar", 1, False] == p.execute()
+    assert [True, "bar", 1] == p.execute()
+    assert client.exists("foo") == False

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -10,23 +10,23 @@ from .conftest import skip_ifmodversion_lt
 def client():
     rc = Client()
     rc.flushdb()
-    return rc.timeseries
+    return rc
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testCreate(client):
-    assert client.create(1)
-    assert client.create(2, retention_msecs=5)
-    assert client.create(3, labels={"Redis": "Labs"})
-    assert client.create(4, retention_msecs=20, labels={"Time": "Series"})
-    info = client.info(4)
+    assert client.tf.create(1)
+    assert client.tf.create(2, retention_msecs=5)
+    assert client.tf.create(3, labels={"Redis": "Labs"})
+    assert client.tf.create(4, retention_msecs=20, labels={"Time": "Series"})
+    info = client.tf.info(4)
     assert 20 == info.retention_msecs
     assert "Series" == info.labels["Time"]
 
     # Test for a chunk size of 128 Bytes
-    assert client.create("time-serie-1", chunk_size=128)
-    info = client.info("time-serie-1")
+    assert client.tf.create("time-serie-1", chunk_size=128)
+    info = client.tf.info("time-serie-1")
     assert 128, info.chunk_size
 
 
@@ -37,23 +37,23 @@ def testCreateDuplicatePolicy(client):
     # Test for duplicate policy
     for duplicate_policy in ["block", "last", "first", "min", "max"]:
         ts_name = "time-serie-ooo-{0}".format(duplicate_policy)
-        assert client.create(ts_name, duplicate_policy=duplicate_policy)
-        info = client.info(ts_name)
+        assert client.tf.create(ts_name, duplicate_policy=duplicate_policy)
+        info = client.tf.info(ts_name)
         assert duplicate_policy == info.duplicate_policy
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testAlter(client):
-    assert client.create(1)
-    assert 0 == client.info(1).retention_msecs
-    assert client.alter(1, retention_msecs=10)
-    assert {} == client.info(1).labels
-    assert 10, client.info(1).retention_msecs
-    assert client.alter(1, labels={"Time": "Series"})
-    assert "Series" == client.info(1).labels["Time"]
-    assert 10 == client.info(1).retention_msecs
-    pipe = client.pipeline()
+    assert client.tf.create(1)
+    assert 0 == client.tf.info(1).retention_msecs
+    assert client.tf.alter(1, retention_msecs=10)
+    assert {} == client.tf.info(1).labels
+    assert 10, client.tf.info(1).retention_msecs
+    assert client.tf.alter(1, labels={"Time": "Series"})
+    assert "Series" == client.tf.info(1).labels["Time"]
+    assert 10 == client.tf.info(1).retention_msecs
+    pipe = client.tf.pipeline()
     assert pipe.create(2)
 
 
@@ -61,32 +61,32 @@ def testAlter(client):
 @pytest.mark.timeseries
 @skip_ifmodversion_lt("1.4.0", "timeseries")
 def testAlterDiplicatePolicy(client):
-    assert client.create(1)
-    info = client.info(1)
+    assert client.tf.create(1)
+    info = client.tf.info(1)
     assert info.duplicate_policy is None
-    assert client.alter(1, duplicate_policy="min")
-    info = client.info(1)
+    assert client.tf.alter(1, duplicate_policy="min")
+    info = client.tf.info(1)
     assert "min" == info.duplicate_policy
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testAdd(client):
-    assert 1 == client.add(1, 1, 1)
-    assert 2 == client.add(2, 2, 3, retention_msecs=10)
-    assert 3 == client.add(3, 3, 2, labels={"Redis": "Labs"})
-    assert 4 == client.add(
+    assert 1 == client.tf.add(1, 1, 1)
+    assert 2 == client.tf.add(2, 2, 3, retention_msecs=10)
+    assert 3 == client.tf.add(3, 3, 2, labels={"Redis": "Labs"})
+    assert 4 == client.tf.add(
         4, 4, 2, retention_msecs=10, labels={"Redis": "Labs", "Time": "Series"}
     )
-    assert round(time.time()) == round(float(client.add(5, "*", 1)) / 1000)
+    assert round(time.time()) == round(float(client.tf.add(5, "*", 1)) / 1000)
 
-    info = client.info(4)
+    info = client.tf.info(4)
     assert 10 == info.retention_msecs
     assert "Labs" == info.labels["Redis"]
 
     # Test for a chunk size of 128 Bytes on TS.ADD
-    assert client.add("time-serie-1", 1, 10.0, chunk_size=128)
-    info = client.info("time-serie-1")
+    assert client.tf.add("time-serie-1", 1, 10.0, chunk_size=128)
+    info = client.tf.info("time-serie-1")
     assert 128 == info.chunk_size
 
 
@@ -96,67 +96,67 @@ def testAdd(client):
 def testAddDuplicatePolicy(client):
 
     # Test for duplicate policy BLOCK
-    assert 1 == client.add("time-serie-add-ooo-block", 1, 5.0)
+    assert 1 == client.tf.add("time-serie-add-ooo-block", 1, 5.0)
     with pytest.raises(Exception):
-        client.add("time-serie-add-ooo-block", 1, 5.0, duplicate_policy="block")
+        client.tf.add("time-serie-add-ooo-block", 1, 5.0, duplicate_policy="block")
 
     # Test for duplicate policy LAST
-    assert 1 == client.add("time-serie-add-ooo-last", 1, 5.0)
-    assert 1 == client.add("time-serie-add-ooo-last", 1, 10.0, duplicate_policy="last")
-    assert 10.0 == client.get("time-serie-add-ooo-last")[1]
+    assert 1 == client.tf.add("time-serie-add-ooo-last", 1, 5.0)
+    assert 1 == client.tf.add("time-serie-add-ooo-last", 1, 10.0, duplicate_policy="last")
+    assert 10.0 == client.tf.get("time-serie-add-ooo-last")[1]
 
     # Test for duplicate policy FIRST
-    assert 1 == client.add("time-serie-add-ooo-first", 1, 5.0)
-    assert 1 == client.add(
+    assert 1 == client.tf.add("time-serie-add-ooo-first", 1, 5.0)
+    assert 1 == client.tf.add(
         "time-serie-add-ooo-first", 1, 10.0, duplicate_policy="first"
     )
-    assert 5.0 == client.get("time-serie-add-ooo-first")[1]
+    assert 5.0 == client.tf.get("time-serie-add-ooo-first")[1]
 
     # Test for duplicate policy MAX
-    assert 1 == client.add("time-serie-add-ooo-max", 1, 5.0)
-    assert 1 == client.add("time-serie-add-ooo-max", 1, 10.0, duplicate_policy="max")
-    assert 10.0 == client.get("time-serie-add-ooo-max")[1]
+    assert 1 == client.tf.add("time-serie-add-ooo-max", 1, 5.0)
+    assert 1 == client.tf.add("time-serie-add-ooo-max", 1, 10.0, duplicate_policy="max")
+    assert 10.0 == client.tf.get("time-serie-add-ooo-max")[1]
 
     # Test for duplicate policy MIN
-    assert 1 == client.add("time-serie-add-ooo-min", 1, 5.0)
-    assert 1 == client.add("time-serie-add-ooo-min", 1, 10.0, duplicate_policy="min")
-    assert 5.0 == client.get("time-serie-add-ooo-min")[1]
+    assert 1 == client.tf.add("time-serie-add-ooo-min", 1, 5.0)
+    assert 1 == client.tf.add("time-serie-add-ooo-min", 1, 10.0, duplicate_policy="min")
+    assert 5.0 == client.tf.get("time-serie-add-ooo-min")[1]
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testMAdd(client):
-    client.create("a")
-    assert [1, 2, 3] == client.madd([("a", 1, 5), ("a", 2, 10), ("a", 3, 15)])
+    client.tf.create("a")
+    assert [1, 2, 3] == client.tf.madd([("a", 1, 5), ("a", 2, 10), ("a", 3, 15)])
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testIncrbyDecrby(client):
     for _ in range(100):
-        assert client.incrby(1, 1)
+        assert client.tf.incrby(1, 1)
         sleep(0.001)
-    assert 100 == client.get(1)[1]
+    assert 100 == client.tf.get(1)[1]
     for _ in range(100):
-        assert client.decrby(1, 1)
+        assert client.tf.decrby(1, 1)
         sleep(0.001)
-    assert 0 == client.get(1)[1]
+    assert 0 == client.tf.get(1)[1]
 
-    assert client.incrby(2, 1.5, timestamp=5)
-    assert (5, 1.5) == client.get(2)
-    assert client.incrby(2, 2.25, timestamp=7)
-    assert (7, 3.75) == client.get(2)
-    assert client.decrby(2, 1.5, timestamp=15)
-    assert (15, 2.25) == client.get(2)
+    assert client.tf.incrby(2, 1.5, timestamp=5)
+    assert (5, 1.5) == client.tf.get(2)
+    assert client.tf.incrby(2, 2.25, timestamp=7)
+    assert (7, 3.75) == client.tf.get(2)
+    assert client.tf.decrby(2, 1.5, timestamp=15)
+    assert (15, 2.25) == client.tf.get(2)
 
     # Test for a chunk size of 128 Bytes on TS.INCRBY
-    assert client.incrby("time-serie-1", 10, chunk_size=128)
-    info = client.info("time-serie-1")
+    assert client.tf.incrby("time-serie-1", 10, chunk_size=128)
+    info = client.tf.info("time-serie-1")
     assert 128 == info.chunk_size
 
     # Test for a chunk size of 128 Bytes on TS.DECRBY
-    assert client.decrby("time-serie-2", 10, chunk_size=128)
-    info = client.info("time-serie-2")
+    assert client.tf.decrby("time-serie-2", 10, chunk_size=128)
+    info = client.tf.info("time-serie-2")
     assert 128 == info.chunk_size
 
 
@@ -165,20 +165,20 @@ def testIncrbyDecrby(client):
 def testCreateAndDeleteRule(client):
     # test rule creation
     time = 100
-    client.create(1)
-    client.create(2)
-    client.createrule(1, 2, "avg", 100)
+    client.tf.create(1)
+    client.tf.create(2)
+    client.tf.createrule(1, 2, "avg", 100)
     for i in range(50):
-        client.add(1, time + i * 2, 1)
-        client.add(1, time + i * 2 + 1, 2)
-    client.add(1, time * 2, 1.5)
-    assert round(client.get(2)[1], 5) == 1.5
-    info = client.info(1)
+        client.tf.add(1, time + i * 2, 1)
+        client.tf.add(1, time + i * 2 + 1, 2)
+    client.tf.add(1, time * 2, 1.5)
+    assert round(client.tf.get(2)[1], 5) == 1.5
+    info = client.tf.info(1)
     assert info.rules[0][1] == 100
 
     # test rule deletion
-    client.deleterule(1, 2)
-    info = client.info(1)
+    client.tf.deleterule(1, 2)
+    info = client.tf.info(1)
     assert not info.rules
 
 
@@ -187,31 +187,31 @@ def testCreateAndDeleteRule(client):
 @skip_ifmodversion_lt("99.99.99", "timeseries")  # todo: update after the release
 def testDelRange(client):
     try:
-        client.delrange("test", 0, 100)
+        client.tf.delrange("test", 0, 100)
     except Exception as e:
         assert e.__str__() is not ""
 
     for i in range(100):
-        client.add(1, i, i % 7)
-    assert 22 == client.delrange(1, 0, 21)
-    assert [] == client.range(1, 0, 21)
-    assert [(22, 1.0)] == client.range(1, 22, 22)
+        client.tf.add(1, i, i % 7)
+    assert 22 == client.tf.delrange(1, 0, 21)
+    assert [] == client.tf.range(1, 0, 21)
+    assert [(22, 1.0)] == client.tf.range(1, 22, 22)
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testRange(client):
     for i in range(100):
-        client.add(1, i, i % 7)
-    assert 100 == len(client.range(1, 0, 200))
+        client.tf.add(1, i, i % 7)
+    assert 100 == len(client.tf.range(1, 0, 200))
     for i in range(100):
-        client.add(1, i + 200, i % 7)
-    assert 200 == len(client.range(1, 0, 500))
+        client.tf.add(1, i + 200, i % 7)
+    assert 200 == len(client.tf.range(1, 0, 500))
     # last sample isn't returned
     assert 20 == len(
-        client.range(1, 0, 500, aggregation_type="avg", bucket_size_msec=10)
+        client.tf.range(1, 0, 500, aggregation_type="avg", bucket_size_msec=10)
     )
-    assert 10 == len(client.range(1, 0, 500, count=10))
+    assert 10 == len(client.tf.range(1, 0, 500, count=10))
 
 
 @pytest.mark.integrations
@@ -219,11 +219,11 @@ def testRange(client):
 @skip_ifmodversion_lt("99.99.99", "timeseries")  # todo: update after the release
 def testRangeAdvanced(client):
     for i in range(100):
-        client.add(1, i, i % 7)
-        client.add(1, i + 200, i % 7)
+        client.tf.add(1, i, i % 7)
+        client.tf.add(1, i + 200, i % 7)
 
     assert 2 == len(
-        client.range(
+        client.tf.range(
             1,
             0,
             500,
@@ -232,10 +232,10 @@ def testRangeAdvanced(client):
             filter_by_max_value=2,
         )
     )
-    assert [(0, 10.0), (10, 1.0)] == client.range(
+    assert [(0, 10.0), (10, 1.0)] == client.tf.range(
         1, 0, 10, aggregation_type="count", bucket_size_msec=10, align="+"
     )
-    assert [(-5, 5.0), (5, 6.0)] == client.range(
+    assert [(-5, 5.0), (5, 6.0)] == client.tf.range(
         1, 0, 10, aggregation_type="count", bucket_size_msec=10, align=5
     )
 
@@ -245,18 +245,18 @@ def testRangeAdvanced(client):
 @skip_ifmodversion_lt("99.99.99", "timeseries")  # todo: update after the release
 def testRevRange(client):
     for i in range(100):
-        client.add(1, i, i % 7)
-    assert 100 == len(client.range(1, 0, 200))
+        client.tf.add(1, i, i % 7)
+    assert 100 == len(client.tf.range(1, 0, 200))
     for i in range(100):
-        client.add(1, i + 200, i % 7)
-    assert 200 == len(client.range(1, 0, 500))
+        client.tf.add(1, i + 200, i % 7)
+    assert 200 == len(client.tf.range(1, 0, 500))
     # first sample isn't returned
     assert 20 == len(
-        client.revrange(1, 0, 500, aggregation_type="avg", bucket_size_msec=10)
+        client.tf.revrange(1, 0, 500, aggregation_type="avg", bucket_size_msec=10)
     )
-    assert 10 == len(client.revrange(1, 0, 500, count=10))
+    assert 10 == len(client.tf.revrange(1, 0, 500, count=10))
     assert 2 == len(
-        client.revrange(
+        client.tf.revrange(
             1,
             0,
             500,
@@ -265,10 +265,10 @@ def testRevRange(client):
             filter_by_max_value=2,
         )
     )
-    assert [(10, 1.0), (0, 10.0)] == client.revrange(
+    assert [(10, 1.0), (0, 10.0)] == client.tf.revrange(
         1, 0, 10, aggregation_type="count", bucket_size_msec=10, align="+"
     )
-    assert [(1, 10.0), (-9, 1.0)] == client.revrange(
+    assert [(1, 10.0), (-9, 1.0)] == client.tf.revrange(
         1, 0, 10, aggregation_type="count", bucket_size_msec=10, align=1
     )
 
@@ -276,22 +276,22 @@ def testRevRange(client):
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testMultiRange(client):
-    client.create(1, labels={"Test": "This", "team": "ny"})
-    client.create(2, labels={"Test": "This", "Taste": "That", "team": "sf"})
+    client.tf.create(1, labels={"Test": "This", "team": "ny"})
+    client.tf.create(2, labels={"Test": "This", "Taste": "That", "team": "sf"})
     for i in range(100):
-        client.add(1, i, i % 7)
-        client.add(2, i, i % 11)
+        client.tf.add(1, i, i % 7)
+        client.tf.add(2, i, i % 11)
 
-    res = client.mrange(0, 200, filters=["Test=This"])
+    res = client.tf.mrange(0, 200, filters=["Test=This"])
     assert 2 == len(res)
     assert 100 == len(res[0]["1"][1])
 
-    res = client.mrange(0, 200, filters=["Test=This"], count=10)
+    res = client.tf.mrange(0, 200, filters=["Test=This"], count=10)
     assert 10 == len(res[0]["1"][1])
 
     for i in range(100):
-        client.add(1, i + 200, i % 7)
-    res = client.mrange(
+        client.tf.add(1, i + 200, i % 7)
+    res = client.tf.mrange(
         0, 500, filters=["Test=This"], aggregation_type="avg", bucket_size_msec=10
     )
     assert 2 == len(res)
@@ -299,7 +299,7 @@ def testMultiRange(client):
 
     # test withlabels
     assert {} == res[0]["1"][0]
-    res = client.mrange(0, 200, filters=["Test=This"], with_labels=True)
+    res = client.tf.mrange(0, 200, filters=["Test=This"], with_labels=True)
     assert {"Test": "This", "team": "ny"} == res[0]["1"][0]
 
 
@@ -307,19 +307,19 @@ def testMultiRange(client):
 @pytest.mark.timeseries
 @skip_ifmodversion_lt("99.99.99", "timeseries")  # todo: update after the release
 def testMultiRangeAdvanced(client):
-    client.create(1, labels={"Test": "This", "team": "ny"})
-    client.create(2, labels={"Test": "This", "Taste": "That", "team": "sf"})
+    client.tf.create(1, labels={"Test": "This", "team": "ny"})
+    client.tf.create(2, labels={"Test": "This", "Taste": "That", "team": "sf"})
     for i in range(100):
-        client.add(1, i, i % 7)
-        client.add(2, i, i % 11)
+        client.tf.add(1, i, i % 7)
+        client.tf.add(2, i, i % 11)
 
     # test with selected labels
-    res = client.mrange(0, 200, filters=["Test=This"], select_labels=["team"])
+    res = client.tf.mrange(0, 200, filters=["Test=This"], select_labels=["team"])
     assert {"team": "ny"} == res[0]["1"][0]
     assert {"team": "sf"} == res[1]["2"][0]
 
     # test with filterby
-    res = client.mrange(
+    res = client.tf.mrange(
         0,
         200,
         filters=["Test=This"],
@@ -330,17 +330,17 @@ def testMultiRangeAdvanced(client):
     assert [(15, 1.0), (16, 2.0)] == res[0]["1"][1]
 
     # test groupby
-    res = client.mrange(0, 3, filters=["Test=This"], groupby="Test", reduce="sum")
+    res = client.tf.mrange(0, 3, filters=["Test=This"], groupby="Test", reduce="sum")
     assert [(0, 0.0), (1, 2.0), (2, 4.0), (3, 6.0)] == res[0]["Test=This"][1]
-    res = client.mrange(0, 3, filters=["Test=This"], groupby="Test", reduce="max")
+    res = client.tf.mrange(0, 3, filters=["Test=This"], groupby="Test", reduce="max")
     assert [(0, 0.0), (1, 1.0), (2, 2.0), (3, 3.0)] == res[0]["Test=This"][1]
-    res = client.mrange(0, 3, filters=["Test=This"], groupby="team", reduce="min")
+    res = client.tf.mrange(0, 3, filters=["Test=This"], groupby="team", reduce="min")
     assert 2 == len(res)
     assert [(0, 0.0), (1, 1.0), (2, 2.0), (3, 3.0)] == res[0]["team=ny"][1]
     assert [(0, 0.0), (1, 1.0), (2, 2.0), (3, 3.0)] == res[1]["team=sf"][1]
 
     # test align
-    res = client.mrange(
+    res = client.tf.mrange(
         0,
         10,
         filters=["team=ny"],
@@ -349,7 +349,7 @@ def testMultiRangeAdvanced(client):
         align="-",
     )
     assert [(0, 10.0), (10, 1.0)] == res[0]["1"][1]
-    res = client.mrange(
+    res = client.tf.mrange(
         0,
         10,
         filters=["team=ny"],
@@ -364,22 +364,22 @@ def testMultiRangeAdvanced(client):
 @pytest.mark.timeseries
 @skip_ifmodversion_lt("99.99.99", "timeseries")  # todo: update after the release
 def testMultiReverseRange(client):
-    client.create(1, labels={"Test": "This", "team": "ny"})
-    client.create(2, labels={"Test": "This", "Taste": "That", "team": "sf"})
+    client.tf.create(1, labels={"Test": "This", "team": "ny"})
+    client.tf.create(2, labels={"Test": "This", "Taste": "That", "team": "sf"})
     for i in range(100):
-        client.add(1, i, i % 7)
-        client.add(2, i, i % 11)
+        client.tf.add(1, i, i % 7)
+        client.tf.add(2, i, i % 11)
 
-    res = client.mrange(0, 200, filters=["Test=This"])
+    res = client.tf.mrange(0, 200, filters=["Test=This"])
     assert 2 == len(res)
     assert 100 == len(res[0]["1"][1])
 
-    res = client.mrange(0, 200, filters=["Test=This"], count=10)
+    res = client.tf.mrange(0, 200, filters=["Test=This"], count=10)
     assert 10 == len(res[0]["1"][1])
 
     for i in range(100):
-        client.add(1, i + 200, i % 7)
-    res = client.mrevrange(
+        client.tf.add(1, i + 200, i % 7)
+    res = client.tf.mrevrange(
         0, 500, filters=["Test=This"], aggregation_type="avg", bucket_size_msec=10
     )
     assert 2 == len(res)
@@ -387,16 +387,16 @@ def testMultiReverseRange(client):
     assert {} == res[0]["1"][0]
 
     # test withlabels
-    res = client.mrevrange(0, 200, filters=["Test=This"], with_labels=True)
+    res = client.tf.mrevrange(0, 200, filters=["Test=This"], with_labels=True)
     assert {"Test": "This", "team": "ny"} == res[0]["1"][0]
 
     # test with selected labels
-    res = client.mrevrange(0, 200, filters=["Test=This"], select_labels=["team"])
+    res = client.tf.mrevrange(0, 200, filters=["Test=This"], select_labels=["team"])
     assert {"team": "ny"} == res[0]["1"][0]
     assert {"team": "sf"} == res[1]["2"][0]
 
     # test filterby
-    res = client.mrevrange(
+    res = client.tf.mrevrange(
         0,
         200,
         filters=["Test=This"],
@@ -407,17 +407,17 @@ def testMultiReverseRange(client):
     assert [(16, 2.0), (15, 1.0)] == res[0]["1"][1]
 
     # test groupby
-    res = client.mrevrange(0, 3, filters=["Test=This"], groupby="Test", reduce="sum")
+    res = client.tf.mrevrange(0, 3, filters=["Test=This"], groupby="Test", reduce="sum")
     assert [(3, 6.0), (2, 4.0), (1, 2.0), (0, 0.0)] == res[0]["Test=This"][1]
-    res = client.mrevrange(0, 3, filters=["Test=This"], groupby="Test", reduce="max")
+    res = client.tf.mrevrange(0, 3, filters=["Test=This"], groupby="Test", reduce="max")
     assert [(3, 3.0), (2, 2.0), (1, 1.0), (0, 0.0)] == res[0]["Test=This"][1]
-    res = client.mrevrange(0, 3, filters=["Test=This"], groupby="team", reduce="min")
+    res = client.tf.mrevrange(0, 3, filters=["Test=This"], groupby="team", reduce="min")
     assert 2 == len(res)
     assert [(3, 3.0), (2, 2.0), (1, 1.0), (0, 0.0)] == res[0]["team=ny"][1]
     assert [(3, 3.0), (2, 2.0), (1, 1.0), (0, 0.0)] == res[1]["team=sf"][1]
 
     # test align
-    res = client.mrevrange(
+    res = client.tf.mrevrange(
         0,
         10,
         filters=["team=ny"],
@@ -426,7 +426,7 @@ def testMultiReverseRange(client):
         align="-",
     )
     assert [(10, 1.0), (0, 10.0)] == res[0]["1"][1]
-    res = client.mrevrange(
+    res = client.tf.mrevrange(
         0,
         10,
         filters=["team=ny"],
@@ -441,41 +441,41 @@ def testMultiReverseRange(client):
 @pytest.mark.timeseries
 def testGet(client):
     name = "test"
-    client.create(name)
-    assert client.get(name) is None
-    client.add(name, 2, 3)
-    assert 2 == client.get(name)[0]
-    client.add(name, 3, 4)
-    assert 4 == client.get(name)[1]
+    client.tf.create(name)
+    assert client.tf.get(name) is None
+    client.tf.add(name, 2, 3)
+    assert 2 == client.tf.get(name)[0]
+    client.tf.add(name, 3, 4)
+    assert 4 == client.tf.get(name)[1]
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testMGet(client):
-    client.create(1, labels={"Test": "This"})
-    client.create(2, labels={"Test": "This", "Taste": "That"})
-    act_res = client.mget(["Test=This"])
+    client.tf.create(1, labels={"Test": "This"})
+    client.tf.create(2, labels={"Test": "This", "Taste": "That"})
+    act_res = client.tf.mget(["Test=This"])
     exp_res = [{"1": [{}, None, None]}, {"2": [{}, None, None]}]
     assert act_res == exp_res
-    client.add(1, "*", 15)
-    client.add(2, "*", 25)
-    res = client.mget(["Test=This"])
+    client.tf.add(1, "*", 15)
+    client.tf.add(2, "*", 25)
+    res = client.tf.mget(["Test=This"])
     assert 15 == res[0]["1"][2]
     assert 25 == res[1]["2"][2]
-    res = client.mget(["Taste=That"])
+    res = client.tf.mget(["Taste=That"])
     assert 25 == res[0]["2"][2]
 
     # test with_labels
     assert {} == res[0]["2"][0]
-    res = client.mget(["Taste=That"], with_labels=True)
+    res = client.tf.mget(["Taste=That"], with_labels=True)
     assert {"Taste": "That", "Test": "This"} == res[0]["2"][0]
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testInfo(client):
-    client.create(1, retention_msecs=5, labels={"currentLabel": "currentData"})
-    info = client.info(1)
+    client.tf.create(1, retention_msecs=5, labels={"currentLabel": "currentData"})
+    info = client.tf.info(1)
     assert 5 == info.retention_msecs
     assert info.labels["currentLabel"] == "currentData"
 
@@ -484,46 +484,46 @@ def testInfo(client):
 @pytest.mark.timeseries
 @skip_ifmodversion_lt("1.4.0", "timeseries")
 def testInfoDuplicatePolicy(client):
-    client.create(1, retention_msecs=5, labels={"currentLabel": "currentData"})
-    info = client.info(1)
+    client.tf.create(1, retention_msecs=5, labels={"currentLabel": "currentData"})
+    info = client.tf.info(1)
     assert info.duplicate_policy is None
 
-    client.create("time-serie-2", duplicate_policy="min")
-    info = client.info("time-serie-2")
+    client.tf.create("time-serie-2", duplicate_policy="min")
+    info = client.tf.info("time-serie-2")
     assert "min" == info.duplicate_policy
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testQueryIndex(client):
-    client.create(1, labels={"Test": "This"})
-    client.create(2, labels={"Test": "This", "Taste": "That"})
-    assert 2 == len(client.queryindex(["Test=This"]))
-    assert 1 == len(client.queryindex(["Taste=That"]))
-    assert ["2"] == client.queryindex(["Taste=That"])
+    client.tf.create(1, labels={"Test": "This"})
+    client.tf.create(2, labels={"Test": "This", "Taste": "That"})
+    assert 2 == len(client.tf.queryindex(["Test=This"]))
+    assert 1 == len(client.tf.queryindex(["Taste=That"]))
+    assert ["2"] == client.tf.queryindex(["Taste=That"])
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 @pytest.mark.pipeline
 def testPipeline(client):
-    pipeline = client.pipeline()
+    pipeline = client.tf.pipeline()
     pipeline.create("with_pipeline")
     for i in range(100):
         pipeline.add("with_pipeline", i, 1.1 * i)
     pipeline.execute()
 
-    info = client.info("with_pipeline")
+    info = client.tf.info("with_pipeline")
     assert info.lastTimeStamp == 99
     assert info.total_samples == 100
-    assert client.get("with_pipeline")[1] == 99 * 1.1
+    assert client.tf.get("with_pipeline")[1] == 99 * 1.1
 
 
 @pytest.mark.integrations
 @pytest.mark.timeseries
 def testUncompressed(client):
-    client.create("compressed")
-    client.create("uncompressed", uncompressed=True)
-    compressed_info = client.info("compressed")
-    uncompressed_info = client.info("uncompressed")
+    client.tf.create("compressed")
+    client.tf.create("uncompressed", uncompressed=True)
+    compressed_info = client.tf.info("compressed")
+    uncompressed_info = client.tf.info("uncompressed")
     assert compressed_info.memory_usage != uncompressed_info.memory_usage

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -102,7 +102,9 @@ def testAddDuplicatePolicy(client):
 
     # Test for duplicate policy LAST
     assert 1 == client.tf.add("time-serie-add-ooo-last", 1, 5.0)
-    assert 1 == client.tf.add("time-serie-add-ooo-last", 1, 10.0, duplicate_policy="last")
+    assert 1 == client.tf.add(
+        "time-serie-add-ooo-last", 1, 10.0, duplicate_policy="last"
+    )
     assert 10.0 == client.tf.get("time-serie-add-ooo-last")[1]
 
     # Test for duplicate policy FIRST


### PR DESCRIPTION
- renaming client usage through the modules.
- black
- pipeline in the abstract, unless overridden
