### PR TITLE
Add support to GRAPH.PROFILE

### DIFF
--- a/redisplus/graph/__init__.py
+++ b/redisplus/graph/__init__.py
@@ -165,7 +165,7 @@ class Graph(CommandMixin, AbstractFeature, object):
             params_header += str(key) + "=" + str(value) + " "
         return params_header
 
-    def query(self, q, params=None, timeout=None, read_only=False):
+    def query(self, q, params=None, timeout=None, read_only=False, profile=False):
         """
         Executes a query against the graph.
 
@@ -174,6 +174,7 @@ class Graph(CommandMixin, AbstractFeature, object):
             params: query parameters
             timeout: maximum runtime for read queries in milliseconds
             read_only: executes a readonly query if set to True
+            profile: return details on results produced by and time spent in each operation.
         """
 
         # maintain original 'q'
@@ -186,7 +187,10 @@ class Graph(CommandMixin, AbstractFeature, object):
         # construct query command
         # ask for compact result-set format
         # specify known graph version
-        cmd = "GRAPH.RO_QUERY" if read_only else "GRAPH.QUERY"
+        if profile:
+            cmd = "GRAPH.PROFILE"
+        else:
+            cmd = "GRAPH.RO_QUERY" if read_only else "GRAPH.QUERY"
         command = [cmd, self.name, query, "--compact"]
 
         # include timeout is specified
@@ -198,7 +202,7 @@ class Graph(CommandMixin, AbstractFeature, object):
         # issue query
         try:
             response = self.execute_command(*command)
-            return QueryResult(self, response)
+            return QueryResult(self, response, profile)
         except ResponseError as e:
             if "wrong number of arguments" in str(e):
                 print("Note: RedisGraph Python requires server version 2.2.8 or above")

--- a/redisplus/graph/__init__.py
+++ b/redisplus/graph/__init__.py
@@ -3,12 +3,9 @@ from .edge import Edge  # noqa
 from .path import Path  # noqa
 
 from redis.client import Redis
-from redis.exceptions import ResponseError
 from ..feature import AbstractFeature
 from ..helpers import random_string, quote_string
 from .commands import CommandMixin
-from .exceptions import VersionMismatchException
-from .query_result import QueryResult
 
 
 class Graph(CommandMixin, AbstractFeature, object):
@@ -131,25 +128,6 @@ class Graph(CommandMixin, AbstractFeature, object):
 
         self.edges.append(edge)
 
-    def commit(self):
-        """
-        Create entire graph.
-        """
-        if len(self.nodes) == 0 and len(self.edges) == 0:
-            return None
-
-        query = "CREATE "
-        for _, node in self.nodes.items():
-            query += str(node) + ","
-
-        query += ",".join([str(edge) for edge in self.edges])
-
-        # Discard leading comma.
-        if query[-1] == ",":
-            query = query[:-1]
-
-        return self.query(query)
-
     def _build_params_header(self, params):
         if not isinstance(params, dict):
             raise TypeError("'params' must be a dict")
@@ -164,69 +142,6 @@ class Graph(CommandMixin, AbstractFeature, object):
                 value = "null"
             params_header += str(key) + "=" + str(value) + " "
         return params_header
-
-    def query(self, q, params=None, timeout=None, read_only=False, profile=False):
-        """
-        Executes a query against the graph.
-
-        Args:
-            q: the query
-            params: query parameters
-            timeout: maximum runtime for read queries in milliseconds
-            read_only: executes a readonly query if set to True
-            profile: return details on results produced by and time spent in each operation.
-        """
-
-        # maintain original 'q'
-        query = q
-
-        # handle query parameters
-        if params is not None:
-            query = self._build_params_header(params) + query
-
-        # construct query command
-        # ask for compact result-set format
-        # specify known graph version
-        if profile:
-            cmd = "GRAPH.PROFILE"
-        else:
-            cmd = "GRAPH.RO_QUERY" if read_only else "GRAPH.QUERY"
-        command = [cmd, self.name, query, "--compact"]
-
-        # include timeout is specified
-        if timeout:
-            if not isinstance(timeout, int):
-                raise Exception("Timeout argument must be a positive integer")
-            command += ["timeout", timeout]
-
-        # issue query
-        try:
-            response = self.execute_command(*command)
-            return QueryResult(self, response, profile)
-        except ResponseError as e:
-            if "wrong number of arguments" in str(e):
-                print("Note: RedisGraph Python requires server version 2.2.8 or above")
-            if "unknown command" in str(e) and read_only:
-                # `GRAPH.RO_QUERY` is unavailable in older versions.
-                return self.query(q, params, timeout, read_only=False)
-            raise e
-        except VersionMismatchException as e:
-            # client view over the graph schema is out of sync
-            # set client version and refresh local schema
-            self.version = e.version
-            self._refresh_schema()
-            # re-issue query
-            return self.query(q, params, timeout, read_only)
-
-    def merge(self, pattern):
-        """
-        Merge pattern.
-        """
-
-        query = "MERGE "
-        query += str(pattern)
-
-        return self.query(query)
 
     # Procedures.
     def call_procedure(self, procedure, *args, read_only=False, **kwagrs):

--- a/redisplus/graph/commands.py
+++ b/redisplus/graph/commands.py
@@ -29,3 +29,6 @@ class CommandMixin:
 
         plan = self.execute_command("GRAPH.EXPLAIN", self.name, query)
         return "\n".join(plan)
+
+    def profile(self, query):
+        return self.query(query, profile=True)

--- a/redisplus/graph/query_result.py
+++ b/redisplus/graph/query_result.py
@@ -60,11 +60,19 @@ class ResultSetScalarTypes:
 
 class QueryResult:
     def __init__(self, graph, response, profile=False):
+        """
+        A class that represents a result of the query operation.
+
+        Args:
+            graph: The graph on which the query was executed.
+            response: The response from the server.
+            profile: A boolean indicating if the query command was "GRAPH.PROFILE"
+        """
         self.graph = graph
         self.header = []
         self.result_set = []
 
-        # incase of an error an exception will be raised
+        # in case of an error an exception will be raised
         self._check_for_errors(response)
 
         if len(response) == 1:

--- a/redisplus/graph/query_result.py
+++ b/redisplus/graph/query_result.py
@@ -59,7 +59,7 @@ class ResultSetScalarTypes:
 
 
 class QueryResult:
-    def __init__(self, graph, response):
+    def __init__(self, graph, response, profile=False):
         self.graph = graph
         self.header = []
         self.result_set = []
@@ -69,6 +69,8 @@ class QueryResult:
 
         if len(response) == 1:
             self.parse_statistics(response[0])
+        elif profile:
+            self.parse_profile(response)
         else:
             # start by parsing statistics, matches the one we have
             self.parse_statistics(response[-1])  # Last element.
@@ -254,6 +256,9 @@ class QueryResult:
             print("Unknown scalar type\n")
 
         return scalar
+
+    def parse_profile(self, response):
+        self.result_set = [x[0 : x.index(",")].strip() for x in response]
 
     # """Prints the data from the query response:
     #    1. First row result_set contains the columns names. Thus the first row in PrettyTable

--- a/tests/graph/test_integrations.py
+++ b/tests/graph/test_integrations.py
@@ -329,6 +329,22 @@ def test_read_only_query(client):
 
 @pytest.mark.integrations
 @pytest.mark.graph
+def test_profile(client):
+    q = """UNWIND range(1, 3) AS x CREATE (p:Person {v:x})"""
+    profile = client.profile(q).result_set
+    assert "Create | Records produced: 3" in profile
+    assert "Unwind | Records produced: 3" in profile
+
+    q = "MATCH (p:Person) WHERE p.v > 1 RETURN p"
+    profile = client.profile(q).result_set
+    assert "Results | Records produced: 2" in profile
+    assert "Project | Records produced: 2" in profile
+    assert "Filter | Records produced: 2" in profile
+    assert "Node By Label Scan | (p:Person) | Records produced: 3" in profile
+
+
+@pytest.mark.integrations
+@pytest.mark.graph
 def test_cache_sync(client):
     pass
     return


### PR DESCRIPTION
Because the query is a complicated method and the `GRAPH.PROFILE` command is executing a query, I tried to use the query function and add support also to profile.
The user can specify True for executing `GRAPH.PROFILE` in query, and also can use the dedicated function `profile`. 

Reference to the test from RedisGraph: https://github.com/RedisGraph/RedisGraph/blob/92046602a775dcba2396d493597b60043f0e39bb/tests/flow/test_profile.py