### PR TITLE
GRAPH.CONFIG

### DIFF
--- a/redisplus/graph/commands.py
+++ b/redisplus/graph/commands.py
@@ -1,3 +1,6 @@
+from redis import DataError
+
+
 class CommandMixin:
     def delete(self):
         """
@@ -29,3 +32,20 @@ class CommandMixin:
 
         plan = self.execute_command("GRAPH.EXPLAIN", self.name, query)
         return "\n".join(plan)
+
+    def config(self, name, value=None, set=False):
+        """
+        Retrieve or update a RedisGraph configuration.
+
+        Args:
+            name: The name of the configuration
+            value: The value we want to ser (can be used only when ``set`` is on)
+            set: turn on to set a configuration. Default behavior is get.
+        """
+        params = ["SET" if set else "GET", name]
+        if value is not None:
+            if set:
+                params.append(value)
+            else:
+                raise DataError("``value`` can be provided only when ``set`` is True")
+        return self.execute_command("GRAPH.CONFIG", *params)

--- a/tests/graph/test_integrations.py
+++ b/tests/graph/test_integrations.py
@@ -329,6 +329,38 @@ def test_read_only_query(client):
 
 @pytest.mark.integrations
 @pytest.mark.graph
+def test_config(client):
+    config_name = "RESULTSET_SIZE"
+    config_value = 3
+
+    # Set configuration
+    response = client.config(config_name, config_value, set=True)
+    assert response == "OK"
+
+    # Make sure config been updated.
+    response = client.config(config_name, set=False)
+    expected_response = [config_name, config_value]
+    assert response == expected_response
+
+    config_name = "QUERY_MEM_CAPACITY"
+    config_value = 1 << 20  # 1MB
+
+    # Set configuration
+    response = client.config(config_name, config_value, set=True)
+    assert response == "OK"
+
+    # Make sure config been updated.
+    response = client.config(config_name, set=False)
+    expected_response = [config_name, config_value]
+    assert response == expected_response
+
+    # reset to default
+    client.config("QUERY_MEM_CAPACITY", 0, set=True)
+    client.config("RESULTSET_SIZE", -100, set=True)
+
+
+@pytest.mark.integrations
+@pytest.mark.graph
 def test_cache_sync(client):
     pass
     return


### PR DESCRIPTION
Add support to `GRAPH.CONFIG` [command](https://oss.redis.com/redisgraph/commands/#graphconfig) 

Test reference: https://github.com/RedisGraph/RedisGraph/blob/master/tests/flow/test_config.py