### PR TITLE
graph.list

### DIFF
--- a/redisplus/graph/__init__.py
+++ b/redisplus/graph/__init__.py
@@ -92,12 +92,12 @@ class Graph(CommandMixin, AbstractFeature, object):
             idx: The index of the relation
         """
         try:
-            relationshipType = self._relationshipTypes[idx]
+            relationship_type = self._relationshipTypes[idx]
         except IndexError:
             # Refresh relationship types.
             self._refresh_relations()
-            relationshipType = self._relationshipTypes[idx]
-        return relationshipType
+            relationship_type = self._relationshipTypes[idx]
+        return relationship_type
 
     def get_property(self, idx):
         """

--- a/redisplus/graph/commands.py
+++ b/redisplus/graph/commands.py
@@ -1,3 +1,6 @@
+from redis import DataError
+
+
 class CommandMixin:
     def delete(self):
         """
@@ -29,3 +32,20 @@ class CommandMixin:
 
         plan = self.execute_command("GRAPH.EXPLAIN", self.name, query)
         return "\n".join(plan)
+
+    def config(self, name, value=None, set=False):
+        """
+        Retrieve or update a RedisGraph configuration.
+
+        Args:
+            name: The name of the configuration
+            value: The value we want to ser (can be used only when ``set`` is on)
+            set: turn on to set a configuration. Default behavior is get.
+        """
+        params = ["SET" if set else "GET", name]
+        if value is not None:
+            if set:
+                params.append(value)
+            else:
+                raise DataError("``value`` can be provided only when ``set`` is True")
+        return self.execute_command("GRAPH.CONFIG", *params)

--- a/redisplus/graph/commands.py
+++ b/redisplus/graph/commands.py
@@ -33,6 +33,18 @@ class CommandMixin:
         plan = self.execute_command("GRAPH.EXPLAIN", self.name, query)
         return "\n".join(plan)
 
+    def slowlog(self):
+        """
+        Get a list containing up to 10 of the slowest queries issued against the given graph ID.
+
+        Each item in the list has the following structure:
+        1. A unix timestamp at which the log entry was processed.
+        2. The issued command.
+        3. The issued query.
+        4. The amount of time needed for its execution, in milliseconds.
+        """
+        return self.execute_command("GRAPH.SLOWLOG", self.name)
+
     def config(self, name, value=None, set=False):
         """
         Retrieve or update a RedisGraph configuration.

--- a/redisplus/graph/commands.py
+++ b/redisplus/graph/commands.py
@@ -61,3 +61,6 @@ class CommandMixin:
             else:
                 raise DataError("``value`` can be provided only when ``set`` is True")
         return self.execute_command("GRAPH.CONFIG", *params)
+
+    def list(self):
+        return self.execute_command("GRAPH.LIST")

--- a/tests/graph/test_integrations.py
+++ b/tests/graph/test_integrations.py
@@ -318,6 +318,30 @@ def test_slowlog(client):
 
 @pytest.mark.integrations
 @pytest.mark.graph
+def test_list(client):
+    result = client.graph.list()
+    assert result == []
+
+    client.execute_command("GRAPH.EXPLAIN", "G", "RETURN 1")
+    result = client.graph.list()
+    assert result == ["G"]
+
+    client.execute_command("GRAPH.EXPLAIN", "X", "RETURN 1")
+    result = client.graph.list()
+    assert result == ["G", "X"]
+
+    client.delete("G")
+    client.rename("X", "Z")
+    result = client.graph.list()
+    assert result == ["Z"]
+
+    client.delete("Z")
+    result = client.graph.list()
+    assert result == []
+
+
+@pytest.mark.integrations
+@pytest.mark.graph
 def test_query_timeout(client):
     # Build a sample graph with 1000 nodes.
     client.graph.query("UNWIND range(0,1000) as val CREATE ({v: val})")

--- a/tests/graph/test_integrations.py
+++ b/tests/graph/test_integrations.py
@@ -305,6 +305,19 @@ def test_explain(client):
 
 @pytest.mark.integrations
 @pytest.mark.graph
+def test_slowlog(client):
+    create_query = """CREATE (:Rider {name:'Valentino Rossi'})-[:rides]->(:Team {name:'Yamaha'}),
+    (:Rider {name:'Dani Pedrosa'})-[:rides]->(:Team {name:'Honda'}),
+    (:Rider {name:'Andrea Dovizioso'})-[:rides]->(:Team {name:'Ducati'})"""
+    client.query(create_query)
+
+    results = client.slowlog()
+    assert results[0][1] == "GRAPH.QUERY"
+    assert results[0][2] == create_query
+
+
+@pytest.mark.integrations
+@pytest.mark.graph
 def test_query_timeout(client):
     # Build a sample graph with 1000 nodes.
     client.query("UNWIND range(0,1000) as val CREATE ({v: val})")

--- a/tests/graph/test_integrations.py
+++ b/tests/graph/test_integrations.py
@@ -329,6 +329,38 @@ def test_read_only_query(client):
 
 @pytest.mark.integrations
 @pytest.mark.graph
+def test_config(client):
+    config_name = "RESULTSET_SIZE"
+    config_value = 3
+
+    # Set configuration
+    response = client.config(config_name, config_value, set=True)
+    assert response == "OK"
+
+    # Make sure config been updated.
+    response = client.config(config_name, set=False)
+    expected_response = [config_name, config_value]
+    assert response == expected_response
+
+    config_name = "QUERY_MEM_CAPACITY"
+    config_value = 1 << 20  # 1MB
+
+    # Set configuration
+    response = client.config(config_name, config_value, set=True)
+    assert response == "OK"
+
+    # Make sure config been updated.
+    response = client.config(config_name, set=False)
+    expected_response = [config_name, config_value]
+    assert response == expected_response
+
+    # reset to default
+    client.config("QUERY_MEM_CAPACITY", 0, set=True)
+    client.config("RESULTSET_SIZE", -100, set=True)
+
+
+@pytest.mark.integrations
+@pytest.mark.graph
 def test_cache_sync(client):
     pass
     return

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -289,7 +289,7 @@ def testTopK(client):
         "E",
         "E",
     )
-    assert ["D", "A", "B"] == client.bf.topklist("topklist")
+    assert ["A", "B", "D"] == client.bf.topklist("topklist").sort()
     info = client.bf.topkinfo("topklist")
     assert 3 == info.k
     assert 50 == info.width

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -289,7 +289,7 @@ def testTopK(client):
         "E",
         "E",
     )
-    assert ["A", "B", "D"] == client.bf.topklist("topklist").sort()
+    assert ["A", "B", "D"] == sorted(client.bf.topklist("topklist"))
     info = client.bf.topkinfo("topklist")
     assert 3 == info.k
     assert 50 == info.width


### PR DESCRIPTION
Add support to GRAPH.LIST command.

I compared it to `rename_graph_comands` because I used redis commands in the test, so it was easier that way.
This is also the reason that it is failing right now.